### PR TITLE
Awaiting Wiremock to be ready. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     }
 
     testCompile "com.github.tomakehurst:wiremock-jre8:2.26.2"
+    testCompile("org.springframework.retry:spring-retry:1.2.5.RELEASE")
 
     implementation ('org.springframework:spring-web:5.2.3.RELEASE') {
         because 'Transitive dependency. Previous versions have a known vulnerability'

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/RetryService.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/RetryService.java
@@ -1,0 +1,52 @@
+package uk.gov.justice.probation.courtcaseservice;
+
+import static java.time.Duration.ofSeconds;
+
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class RetryService {
+
+    private static final Logger log = LoggerFactory.getLogger(RetryService.class);
+
+    private final WebClient webClient;
+
+    public RetryService(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    /**
+     * Calls a simple wiremock stub. It's a workaround to a problem described here.
+     * @see <a href="https://github.com/tomakehurst/wiremock/issues/1224">Wiremock Issue</a>
+     *
+     * @throws Exception
+     *              if the method fails to call wiremock stub with 200 status
+     */
+    @Retryable(value = {Exception.class}, maxAttempts = 5, backoff = @Backoff(delay = 1000))
+    public void tryWireMockStub() throws Exception {
+        log.debug("Starting call to ... WireMock readiness stub");
+        Optional<ClientResponse> clientResponse = webClient.method(HttpMethod.GET)
+                                                            .uri("/readiness/wiremock")
+                                                            .exchange()
+                                                            .blockOptional(ofSeconds(1));
+
+        if (!clientResponse.map(this::checkCode).orElse(Boolean.FALSE)) {
+            log.warn("Call to {} failed.", "/readiness/wiremock");
+            throw new Exception("Wiremock not ready!");
+        }
+        log.debug("Call to WireMock readiness stub completed with response :{}", clientResponse.get().bodyToMono(String.class).block(ofSeconds(1)));
+    }
+
+    private boolean checkCode(ClientResponse clientResponse) {
+        return clientResponse.statusCode().is2xxSuccessful();
+    }
+}
+

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/TestConfig.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/TestConfig.java
@@ -1,9 +1,14 @@
 package uk.gov.justice.probation.courtcaseservice;
 
 import io.restassured.RestAssured;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
 
+@TestConfiguration
 public class TestConfig {
     public static final String CONFIGURED_TWICE = "Attempt to configure RestAssured for both Integration and Smoke tests is not allowed";
+    public static final int WIREMOCK_PORT = 8090;
     private static boolean configuredForInt = false;
     private static boolean configuredForSmoke = false;
 
@@ -34,5 +39,10 @@ public class TestConfig {
         if (configuredForSmoke) return;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
         configuredForSmoke = true;
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.create("http://localhost:" + WIREMOCK_PORT + "/");
     }
 }

--- a/src/test/resources/mocks/mappings/wiremock-readiness.json
+++ b/src/test/resources/mocks/mappings/wiremock-readiness.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/readiness/wiremock"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "SUCCESS"
+  }
+}


### PR DESCRIPTION
We looked to be hitting the exact same issue described here 
[https://github.com/tomakehurst/wiremock/issues/1224](url)

This ticket reports this 

> we sometimes have failures once Spring launches a fresh context and Spring Security tries to get OAuth2 token (this call is stubbed within WireMock server)

The workaround was to do this

> We now have a workaround and add a simple e.g. /readiness/wiremock stub right after starting the WireMockServer and try to hit it with a simple retry-mechanism and once HTTP status 200 returns we continue we our setup.

The ticket was closed with no fix. So this commit does the same thing as described
