### PR TITLE
Update community API docker URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
 
   community-api:
-    image: mojdigitalstudio/community-api:latest
+    image: quay.io/hmpps/community-api:latest
     networks:
       - hmpps
     container_name: community-api


### PR DESCRIPTION
As per the community-api-pr channel, docker image has moved