### PR TITLE
400 - include breach documents in BreachResponse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.3.0.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/BreachResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/BreachResponse.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.probation.courtcaseservice.controller.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
 
 @Builder
 @Getter
@@ -18,4 +20,6 @@ public class BreachResponse {
     private final String officer;
     private final String status;
     private final String order;
+
+    private final List<OffenderDocumentDetail> documents;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
-import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper.OffenderMapper;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper.DocumentMapper;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.DocumentNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
@@ -32,7 +32,8 @@ public class DocumentRestClient {
     @Value("${community-api.offender-document-by-crn-url-template}")
     private String offenderDocumentUrlTemplate;
     @Autowired
-    private OffenderMapper mapper;
+    private DocumentMapper documentMapper;
+
     @Autowired
     @Qualifier("communityApiClient")
     private RestClientHelper clientHelper;
@@ -43,7 +44,7 @@ public class DocumentRestClient {
             .onStatus(HttpStatus::is4xxClientError, (clientResponse) -> clientHelper.handleOffenderError(crn, clientResponse))
             .bodyToMono(CommunityApiGroupedDocumentsResponse.class)
             .doOnError(e -> log.error(String.format("Unexpected exception when retrieving grouped document data for CRN '%s'", crn), e))
-            .map(documentsResponse -> mapper.documentsFrom(documentsResponse));
+            .map(documentsResponse -> documentMapper.documentsFrom(documentsResponse));
     }
 
     public Mono<ResponseEntity<Resource>> getDocument(String crn, String documentId)  {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapper.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionDocuments;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiOffenderDocumentDetail;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
+
+@Component
+public class DocumentMapper {
+
+    public GroupedDocuments documentsFrom(CommunityApiGroupedDocumentsResponse documentsResponse) {
+        return GroupedDocuments.builder()
+            .documents(Optional.ofNullable(documentsResponse.getDocuments()).map(this::buildDocuments).orElse(Collections.emptyList()))
+            .convictions(Optional.ofNullable(documentsResponse.getConvictions()).map(this::buildConvictionDocuments).orElse(Collections.emptyList()))
+            .build();
+    }
+
+    private List<ConvictionDocuments> buildConvictionDocuments(List<CommunityApiConvictionDocuments> convictionDocuments) {
+        return convictionDocuments.stream()
+                .map(this::buildConvictionDocument)
+                .collect(Collectors.toList());
+    }
+
+    private ConvictionDocuments buildConvictionDocument(CommunityApiConvictionDocuments convictionDocuments) {
+        return ConvictionDocuments.builder()
+            .convictionId(convictionDocuments.getConvictionId())
+            .documents(Optional.ofNullable(convictionDocuments.getDocuments()).map(this::buildConvictionIdDocuments).orElse(Collections.emptyList()))
+            .build();
+    }
+
+    private List<OffenderDocumentDetail> buildConvictionIdDocuments(List<CommunityApiOffenderDocumentDetail> documentDetails) {
+        return documentDetails.stream()
+            .map(this::buildOffenderDocumentDetail)
+            .collect(Collectors.toList());
+    }
+
+    private List<OffenderDocumentDetail> buildDocuments(List<CommunityApiOffenderDocumentDetail> details) {
+        return details.stream()
+            .map(this::buildOffenderDocumentDetail)
+            .collect(Collectors.toList());
+    }
+
+    private OffenderDocumentDetail buildOffenderDocumentDetail(CommunityApiOffenderDocumentDetail detail) {
+        return OffenderDocumentDetail.builder()
+            .documentId(detail.getId())
+            .documentName(detail.getDocumentName())
+            .author(detail.getAuthor())
+            .type(DocumentType.valueOf(detail.getType().getCode()))
+            .extendedDescription(detail.getExtendedDescription())
+            .createdAt(detail.getCreatedAt())
+            .reportDocumentDates(detail.getReportDocumentDates())
+            .subType(detail.getSubType())
+            .parentPrimaryKeyId(detail.getParentPrimaryKeyId())
+            .build();
+    }
+
+}

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/NsiMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/NsiMapper.java
@@ -1,5 +1,10 @@
 package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
 
+import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.NSI_DOCUMENT;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.probation.courtcaseservice.controller.model.BreachResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.*;
@@ -7,10 +12,13 @@ import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 
 import java.util.Comparator;
 import java.util.Optional;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
 
 @Component
 public class NsiMapper {
-    public BreachResponse breachOf(CommunityApiNsi nsi, Conviction conviction) {
+
+    public BreachResponse breachOf(CommunityApiNsi nsi, Conviction conviction, GroupedDocuments breachDocuments) {
         CommunityApiNsiManager nsiManager = getMostRecentNsiManager(nsi)
                 .orElse(CommunityApiNsiManager.builder()
                         .build());
@@ -24,7 +32,8 @@ public class NsiMapper {
                 .team(getTeam(nsiManager))
                 .status(getStatus(nsi))
                 .order(conviction.getSentence().getDescription())
-                .build();
+                .documents(getMatchedDocsFor(breachDocuments, nsi.getNsiId(), conviction.getConvictionId()))
+            .build();
     }
 
     private String getStatus(CommunityApiNsi nsi) {
@@ -53,8 +62,18 @@ public class NsiMapper {
     }
 
     private Optional<CommunityApiNsiManager> getMostRecentNsiManager(CommunityApiNsi nsi) {
-        return nsi.getNsiManagers()
+        return Optional.ofNullable(nsi.getNsiManagers()).orElse(Collections.emptyList())
                 .stream()
                 .max(Comparator.comparing(CommunityApiNsiManager::getStartDate));
+    }
+
+    private List<OffenderDocumentDetail> getMatchedDocsFor(GroupedDocuments groupedDocuments, Long parentTableKeyId, String convictionId) {
+        return Optional.ofNullable(groupedDocuments).orElse(GroupedDocuments.builder().convictions(Collections.emptyList()).build())
+            .getConvictions()
+            .stream()
+            .filter(convictionDoc -> convictionId.equals(convictionDoc.getConvictionId()))
+            .flatMap(matchConvictionDoc -> matchConvictionDoc.getDocuments().stream().filter(doc -> NSI_DOCUMENT.equals(doc.getType())))
+            .filter(matchNsiTypeDoc -> parentTableKeyId.equals(matchNsiTypeDoc.getParentPrimaryKeyId()))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/OffenderMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/OffenderMapper.java
@@ -1,20 +1,27 @@
 package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
 
 import java.time.LocalDate;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.function.BiFunction;
-import org.springframework.stereotype.Component;
-import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.*;
-import uk.gov.justice.probation.courtcaseservice.service.model.*;
-
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionsResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiOffenderManager;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiOffenderResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiRequirementResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiRequirementsResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiSentence;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiUnpaidWork;
+import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
+import uk.gov.justice.probation.courtcaseservice.service.model.Offence;
+import uk.gov.justice.probation.courtcaseservice.service.model.OffenderManager;
+import uk.gov.justice.probation.courtcaseservice.service.model.ProbationRecord;
+import uk.gov.justice.probation.courtcaseservice.service.model.Requirement;
+import uk.gov.justice.probation.courtcaseservice.service.model.Sentence;
+import uk.gov.justice.probation.courtcaseservice.service.model.UnpaidWork;
 
 @Component
 public class OffenderMapper {
@@ -63,51 +70,6 @@ public class OffenderMapper {
         return requirementsResponse.getRequirements().stream()
                 .map(this::buildRequirement)
                 .collect(Collectors.toList());
-    }
-
-    public GroupedDocuments documentsFrom(CommunityApiGroupedDocumentsResponse documentsResponse) {
-        return GroupedDocuments.builder()
-            .documents(Optional.ofNullable(documentsResponse.getDocuments()).map(this::buildDocuments).orElse(Collections.emptyList()))
-            .convictions(Optional.ofNullable(documentsResponse.getConvictions()).map(this::buildConvictionDocuments).orElse(Collections.emptyList()))
-            .build();
-    }
-
-    private List<ConvictionDocuments> buildConvictionDocuments(List<CommunityApiConvictionDocuments> convictionDocuments) {
-        return convictionDocuments.stream()
-                .map(this::buildConvictionDocument)
-                .collect(Collectors.toList());
-    }
-
-    private ConvictionDocuments buildConvictionDocument(CommunityApiConvictionDocuments convictionDocuments) {
-        return ConvictionDocuments.builder()
-            .convictionId(convictionDocuments.getConvictionId())
-            .documents(Optional.ofNullable(convictionDocuments.getDocuments()).map(this::buildConvictionIdDocuments).orElse(Collections.emptyList()))
-            .build();
-    }
-
-    private List<OffenderDocumentDetail> buildConvictionIdDocuments(List<CommunityApiOffenderDocumentDetail> documentDetails) {
-        return documentDetails.stream()
-            .map(this::buildOffenderDocumentDetail)
-            .collect(Collectors.toList());
-    }
-
-    private List<OffenderDocumentDetail> buildDocuments(List<CommunityApiOffenderDocumentDetail> details) {
-        return details.stream()
-            .map(this::buildOffenderDocumentDetail)
-            .collect(Collectors.toList());
-    }
-
-    private OffenderDocumentDetail buildOffenderDocumentDetail(CommunityApiOffenderDocumentDetail detail) {
-        return OffenderDocumentDetail.builder()
-            .documentId(detail.getId())
-            .documentName(detail.getDocumentName())
-            .author(detail.getAuthor())
-            .type(DocumentType.valueOf(detail.getType().getCode()))
-            .extendedDescription(detail.getExtendedDescription())
-            .createdAt(detail.getCreatedAt())
-            .reportDocumentDates(detail.getReportDocumentDates())
-            .subType(detail.getSubType())
-            .build();
     }
 
     private Requirement buildRequirement(CommunityApiRequirementResponse requirement) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/model/CommunityApiOffenderDocumentDetail.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/model/CommunityApiOffenderDocumentDetail.java
@@ -21,6 +21,7 @@ public class CommunityApiOffenderDocumentDetail {
     private String extendedDescription;
     private LocalDateTime lastModifiedAt;
     private LocalDateTime createdAt;
+    private Long parentPrimaryKeyId;
 
     private KeyValue subType;
     private ReportDocumentDates reportDocumentDates;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/BreachService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/BreachService.java
@@ -1,17 +1,17 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.controller.model.BreachResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRestClient;
+import uk.gov.justice.probation.courtcaseservice.restclient.DocumentRestClient;
 import uk.gov.justice.probation.courtcaseservice.restclient.NsiRestClient;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper.NsiMapper;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsi;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.NsiNotFoundException;
-
-import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -19,6 +19,7 @@ public class BreachService {
 
     private final NsiRestClient nsiRestClient;
     private final ConvictionRestClient convictionRestClient;
+    private final DocumentRestClient documentRestClient;
     private final NsiMapper breachMapper;
     @Value("#{'${community-api.nsis-filter.codes.breaches}'.split(',')}")
     private List<String> nsiBreachCodes;
@@ -26,12 +27,13 @@ public class BreachService {
     public BreachResponse getBreach(String crn, Long convictionId, Long breachId) {
         return Mono.zip(
                 nsiRestClient.getNsiById(crn, convictionId, breachId),
-                convictionRestClient.getConviction(crn, convictionId)
+                convictionRestClient.getConviction(crn, convictionId),
+                documentRestClient.getDocumentsByCrn(crn)
         )
                 .map(tuple -> {
                     CommunityApiNsi nsi = tuple.getT1();
                     validateBreach(nsi);
-                    return breachMapper.breachOf(nsi, tuple.getT2());
+                    return breachMapper.breachOf(nsi, tuple.getT2(), tuple.getT3());
                 })
                 .block();
     }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/document/OffenderDocumentDetail.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/document/OffenderDocumentDetail.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.service.model.document;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -23,6 +24,9 @@ public class OffenderDocumentDetail {
     private final DocumentType type;
     private final String extendedDescription;
     private final LocalDateTime createdAt;
+
+    @JsonIgnore
+    private final Long parentPrimaryKeyId;
 
     private KeyValue subType;
     private ReportDocumentDates reportDocumentDates;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -145,10 +145,10 @@ public class OffenderControllerIntTest {
                 .statusCode(200)
                 .body("crn",  equalTo("X320741"))
                 .body("convictions[0].convictionId", equalTo("2500295343"))
-                .body("convictions[0].documents", hasSize(6))
+                .body("convictions[0].documents", hasSize(7))
 
                 .body("convictions[1].convictionId", equalTo("2500295345"))
-                .body("convictions[1].documents", hasSize(9))
+                .body("convictions[1].documents", hasSize(8))
 
                 .body("convictions[2].convictionId", equalTo("2500297061"))
                 .body("convictions[2].documents", hasSize(0))
@@ -205,6 +205,7 @@ public class OffenderControllerIntTest {
                 .body("officer", equalTo("Unallocated Staff"))
                 .body("status", equalTo("Induction Completed - Opted Out"))
                 .body("order", equalTo("CJA - Community Order"))
+                .body("documents", hasSize(1))
         ;
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class OffenderControllerTest {
+class OffenderControllerTest {
     private static final String CRN = "CRN";
     private static final String CONVICTION_ID = "CONVICTION_ID";
     static final Long SOME_EVENT_ID = 1234L;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapperTest.java
@@ -1,0 +1,122 @@
+package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
+
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.SEPTEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.COURT_REPORT_DOCUMENT;
+import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.PRECONS_DOCUMENT;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
+import uk.gov.justice.probation.courtcaseservice.service.model.KeyValue;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.ReportDocumentDates;
+
+public class DocumentMapperTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String BASE_MOCK_PATH = "src/test/resources/mocks/__files/";
+
+    private DocumentMapper mapper;
+
+    @BeforeAll
+    public static void setUpBeforeClass() {
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    }
+
+    @BeforeEach
+    void setUp() {
+        mapper = new DocumentMapper();
+    }
+
+    @DisplayName("Prove that null input lists in the community API will be handled and create empty lists")
+    @Test
+    void shouldMapGroupedDocumentsWithNullsToEmptyDocumentLists() {
+
+        CommunityApiGroupedDocumentsResponse response = new CommunityApiGroupedDocumentsResponse(null, null);
+
+        GroupedDocuments groupedDocuments = mapper.documentsFrom(response);
+
+        assertThat(groupedDocuments.getDocuments()).isEmpty();
+        assertThat(groupedDocuments.getConvictions()).isEmpty();
+    }
+
+    @DisplayName("Maps grouped documents from community API to Court Case Service")
+    @Test
+    void shouldMapGroupedDocumentsToDocuments() throws IOException {
+
+        CommunityApiGroupedDocumentsResponse response
+            = OBJECT_MAPPER.readValue(new File(BASE_MOCK_PATH + "offender-documents/GET_documents_success_X320741.json"), CommunityApiGroupedDocumentsResponse.class);
+
+        GroupedDocuments documentsResponse = mapper.documentsFrom(response);
+
+        // Check sizes and one from each collection
+        assertThat(documentsResponse.getDocuments()).hasSize(7);
+        assertThat(documentsResponse.getConvictions()).hasSize(2);
+
+        assertThat(documentsResponse.getDocuments())
+            .extracting("documentId")
+            .containsExactlyInAnyOrder("1e593ff6-d5d6-4048-a671-cdeb8f65608b", "0ec9b16c-b292-4d27-b11a-c0ddde852804",
+                                    "aeb43e06-a4a1-460f-9acf-e2495de84604", "b2d92238-215c-4d6d-b91c-208ea747087e",
+                                    "5152b060-9650-4f22-9974-038a38590d9f", "7ceda384-3624-4a62-849d-7c729b6d0dd1",
+                                    "2b167448-31a5-45a5-85a5-dcdd4a783f1d");
+
+        OffenderDocumentDetail documentDetail = documentsResponse.getDocuments().stream()
+                                                    .filter(doc -> doc.getDocumentId().equals("1e593ff6-d5d6-4048-a671-cdeb8f65608b"))
+                                                    .findFirst().get();
+        assertThat(documentDetail).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
+                                                                    .documentId("1e593ff6-d5d6-4048-a671-cdeb8f65608b")
+                                                                    .documentName("PRE-CONS.pdf")
+                                                                    .author("Andy Marke")
+                                                                    .type(PRECONS_DOCUMENT)
+                                                                    .extendedDescription("Previous convictions as of 01/09/2019")
+                                                                    .createdAt(LocalDateTime.of(2019, SEPTEMBER, 10, 0, 0, 0))
+                                                                    .build());
+
+        ConvictionDocuments convictionDocuments1 = documentsResponse.getConvictions().stream()
+            .filter(conviction -> conviction.getConvictionId().equals("2500295343"))
+            .findFirst().get();
+        assertThat(convictionDocuments1.getDocuments()).hasSize(7);
+        assertThat(convictionDocuments1.getDocuments())
+            .extracting("documentId")
+            .containsExactlyInAnyOrder("cc8bf04c-2f8c-4e72-a14b-ab6a5702bf59", "ec450eca-cf81-420d-8712-873a5df2274b",
+                "086bfb96-28a7-4b0a-80d5-7b877dd7bb75", "5058ca66-3751-4701-855a-86bf518d9392",
+                "44f37749-18b8-46ff-803a-150746f6d1bc", "b88547cf-7464-4cbc-b5f9-ebe2bafc19d9",
+                "4191eada-6e03-4bd8-b52d-9e050eefa745");
+
+        ConvictionDocuments convictionDocuments2 = documentsResponse.getConvictions().stream()
+            .filter(conviction -> conviction.getConvictionId().equals("2500295345"))
+            .findFirst().get();
+        assertThat(convictionDocuments2.getDocuments()).hasSize(8);
+        OffenderDocumentDetail preSentenceReport = convictionDocuments2.getDocuments().stream()
+            .filter(document -> document.getDocumentName().startsWith("shortFormatPreSentenceReport"))
+            .findFirst().get();
+        assertThat(preSentenceReport).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
+            .documentId("1d842fce-ec2d-45dc-ac9a-748d3076ca6b")
+            .documentName("shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf")
+            .author("Andy Marke")
+            .type(COURT_REPORT_DOCUMENT)
+            .extendedDescription("Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018")
+            .createdAt(LocalDateTime.of(2019, SEPTEMBER, 4, 0, 0, 0))
+            .subType(new KeyValue("CJF", "Pre-Sentence Report - Fast"))
+            .parentPrimaryKeyId(2500079873L)
+            .reportDocumentDates(new ReportDocumentDates(LocalDate.of(2018, SEPTEMBER, 4), LocalDate.of(2019, SEPTEMBER, 4), LocalDateTime.of(2018, FEBRUARY, 28, 0, 0, 0)))
+            .build());
+
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/NsiMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/NsiMapperTest.java
@@ -1,17 +1,31 @@
 package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
 
-import org.junit.jupiter.api.Test;
-import uk.gov.justice.probation.courtcaseservice.controller.model.BreachResponse;
-import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.*;
-import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
-import uk.gov.justice.probation.courtcaseservice.service.model.Sentence;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.NSI_DOCUMENT;
+import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.REFERRAL_DOCUMENT;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.probation.courtcaseservice.controller.model.BreachResponse;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsi;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsiManager;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsiStatus;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiProbationArea;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiStaff;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiStaffWrapper;
+import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiTeam;
+import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
+import uk.gov.justice.probation.courtcaseservice.service.model.Sentence;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class NsiMapperTest {
 
@@ -20,19 +34,24 @@ class NsiMapperTest {
     private static final LocalDate STARTED_DATE = LocalDate.of(2020, 5, 14);
     private static final String OFFICER = "Forename Lastname";
     private static final String PROVIDER = "Some provider";
+    private static final String CONVICTION_ID = "1234";
     private static final String TEAM = "Some Team";
     private static final String BREACH_STATUS = "Breach Status";
     public static final String ORDER = "Some Order";
+
     private final NsiMapper mapper = new NsiMapper();
 
+    @DisplayName("Mapping of all values in NSI")
     @Test
     public void mapValues() {
-        List<CommunityApiNsiManager> nsiManagers = Collections.singletonList(
+        List<CommunityApiNsiManager> nsiManagers = singletonList(
                 buildNsiManager(LocalDate.of(2020, 5, 1), TEAM));
 
         CommunityApiNsi communityApiNsi = buildNsi(nsiManagers);
         Conviction conviction = buildConviction();
-        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction);
+        GroupedDocuments groupedDocuments = buildGroupedDocuments(CONVICTION_ID, NSI_ID);
+
+        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction, groupedDocuments);
 
         assertThat(breach.getBreachId()).isEqualTo(NSI_ID);
         assertThat(breach.getIncidentDate()).isEqualTo(INCIDENT_DATE);
@@ -42,19 +61,23 @@ class NsiMapperTest {
         assertThat(breach.getTeam()).isEqualTo(TEAM);
         assertThat(breach.getStatus()).isEqualTo(BREACH_STATUS);
         assertThat(breach.getOrder()).isEqualTo(ORDER);
+        assertThat(breach.getDocuments()).hasSize(1);
+        assertThat(breach.getDocuments().get(0).getParentPrimaryKeyId()).isEqualTo(NSI_ID);
     }
 
     private Conviction buildConviction() {
         return Conviction.builder()
+                .convictionId(CONVICTION_ID)
                 .sentence(Sentence.builder()
                         .description(ORDER)
                         .build())
                 .build();
     }
 
+    @DisplayName("Selects the most recent team name from NSI managers")
     @Test
     public void givenMultipleNsiManagers_thenGetValuesFromMostRecent() {
-        List<CommunityApiNsiManager> nsiManagers = Arrays.asList(
+        List<CommunityApiNsiManager> nsiManagers = asList(
                 buildNsiManager(LocalDate.of(2020, 5, 5), "Wrong Team"),
                 buildNsiManager(LocalDate.of(2020, 5, 1), "Wrong Team"),
                 buildNsiManager(LocalDate.of(2020, 5, 13), "Expected Team"),
@@ -63,22 +86,46 @@ class NsiMapperTest {
 
         CommunityApiNsi communityApiNsi = buildNsi(nsiManagers);
         Conviction conviction = buildConviction();
-        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction);
+        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction, buildGroupedDocuments(CONVICTION_ID, 123L));
 
         assertThat(breach.getTeam()).isEqualTo("Expected Team");
+        assertThat(breach.getDocuments()).isEmpty();
     }
 
+    @DisplayName("Handling null NSI managers")
+    @Test
+    public void givenNullNsiManagers_thenHandle() {
+
+        CommunityApiNsi communityApiNsi = buildNsi(null);
+        BreachResponse breach = mapper.breachOf(communityApiNsi, buildConviction(), buildGroupedDocuments(CONVICTION_ID, 123L));
+
+        assertThat(breach.getTeam()).isNull();
+        assertThat(breach.getDocuments()).isEmpty();
+    }
+
+    @DisplayName("Handling null grouped documents")
+    @Test
+    public void givenNullGroupedDocuments_thenHandle() {
+
+        BreachResponse breach = mapper.breachOf(buildNsi(Collections.emptyList()), buildConviction(), null);
+
+        assertThat(breach.getDocuments()).isEmpty();
+    }
+
+    @DisplayName("Handling case where there are no NSI managers")
     @Test
     public void givenZeroNsiManagers_thenReturnNullValues() {
         List<CommunityApiNsiManager> nsiManagers = Collections.emptyList();
 
         CommunityApiNsi communityApiNsi = buildNsi(nsiManagers);
         Conviction conviction = buildConviction();
-        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction);
+        GroupedDocuments groupedDocuments = buildGroupedDocuments("NON_MATCH_CONVICTION_ID", NSI_ID);
+        BreachResponse breach = mapper.breachOf(communityApiNsi, conviction, groupedDocuments);
 
         assertThat(breach.getOfficer()).isEqualTo(null);
         assertThat(breach.getProvider()).isEqualTo(null);
         assertThat(breach.getTeam()).isEqualTo(null);
+        assertThat(breach.getDocuments()).isEmpty();
     }
 
     private CommunityApiNsi buildNsi(List<CommunityApiNsiManager> nsiManagers) {
@@ -109,5 +156,33 @@ class NsiMapperTest {
                             .build())
                     .startDate(startDate)
                     .build();
+    }
+
+    private GroupedDocuments buildGroupedDocuments(String convictionId, Long nsiId) {
+
+        OffenderDocumentDetail nsiDocument = buildDocument(nsiId, NSI_DOCUMENT);
+        OffenderDocumentDetail referralReport = buildDocument(nsiId, REFERRAL_DOCUMENT);
+        OffenderDocumentDetail nsiDocNonConviction = buildDocument(null, NSI_DOCUMENT);
+
+        ConvictionDocuments convictionDocs1 = ConvictionDocuments.builder()
+            .convictionId(convictionId)
+            .documents(asList(nsiDocument, referralReport))
+            .build();
+        ConvictionDocuments convictionDocs2 = ConvictionDocuments.builder()
+            .convictionId("NON_MATCH_CONVICTION_ID")
+            .documents(singletonList(referralReport))
+            .build();
+
+        return GroupedDocuments.builder()
+            .documents(singletonList(nsiDocNonConviction))
+            .convictions(asList(convictionDocs1, convictionDocs2))
+            .build();
+    }
+
+    private OffenderDocumentDetail buildDocument(Long parentPrimaryKeyId, DocumentType documentType) {
+        return OffenderDocumentDetail.builder()
+            .parentPrimaryKeyId(parentPrimaryKeyId)
+            .type(documentType)
+            .build();
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/OffenderMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/OffenderMapperTest.java
@@ -1,11 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper;
 
-import static java.time.Month.FEBRUARY;
-import static java.time.Month.SEPTEMBER;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.COURT_REPORT_DOCUMENT;
-import static uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType.PRECONS_DOCUMENT;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,17 +18,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionsResponse;
-import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiOffenderResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiRequirementsResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiSentence;
 import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 import uk.gov.justice.probation.courtcaseservice.service.model.KeyValue;
 import uk.gov.justice.probation.courtcaseservice.service.model.Requirement;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.ReportDocumentDates;
 
 public class OffenderMapperTest {
 
@@ -268,77 +258,4 @@ public class OffenderMapperTest {
         assertThat(emptyResponse.getRequirements()).isEmpty();
     }
 
-    @DisplayName("Prove that null input lists in the community API will be handled and create empty lists")
-    @Test
-    void shouldMapGroupedDocumentsWithNullsToEmptyDocumentLists() {
-
-        CommunityApiGroupedDocumentsResponse response = new CommunityApiGroupedDocumentsResponse(null, null);
-
-        GroupedDocuments groupedDocuments = mapper.documentsFrom(response);
-
-        assertThat(groupedDocuments.getDocuments()).isEmpty();
-        assertThat(groupedDocuments.getConvictions()).isEmpty();
-    }
-
-    @DisplayName("Maps grouped documents from community API to Court Case Service")
-    @Test
-    void shouldMapGroupedDocumentsToDocuments() throws IOException {
-
-        CommunityApiGroupedDocumentsResponse response
-            = OBJECT_MAPPER.readValue(new File(BASE_MOCK_PATH + "offender-documents/GET_documents_success_X320741.json"), CommunityApiGroupedDocumentsResponse.class);
-
-        GroupedDocuments documentsResponse = mapper.documentsFrom(response);
-
-        // Check sizes and one from each collection
-        assertThat(documentsResponse.getDocuments()).hasSize(7);
-        assertThat(documentsResponse.getConvictions()).hasSize(2);
-
-        assertThat(documentsResponse.getDocuments())
-            .extracting("documentId")
-            .containsExactlyInAnyOrder("1e593ff6-d5d6-4048-a671-cdeb8f65608b", "0ec9b16c-b292-4d27-b11a-c0ddde852804",
-                                    "aeb43e06-a4a1-460f-9acf-e2495de84604", "b2d92238-215c-4d6d-b91c-208ea747087e",
-                                    "5152b060-9650-4f22-9974-038a38590d9f", "7ceda384-3624-4a62-849d-7c729b6d0dd1",
-                                    "2b167448-31a5-45a5-85a5-dcdd4a783f1d");
-
-        OffenderDocumentDetail documentDetail = documentsResponse.getDocuments().stream()
-                                                    .filter(doc -> doc.getDocumentId().equals("1e593ff6-d5d6-4048-a671-cdeb8f65608b"))
-                                                    .findFirst().get();
-        assertThat(documentDetail).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
-                                                                    .documentId("1e593ff6-d5d6-4048-a671-cdeb8f65608b")
-                                                                    .documentName("PRE-CONS.pdf")
-                                                                    .author("Andy Marke")
-                                                                    .type(PRECONS_DOCUMENT)
-                                                                    .extendedDescription("Previous convictions as of 01/09/2019")
-                                                                    .createdAt(LocalDateTime.of(2019, SEPTEMBER, 10, 0, 0, 0))
-                                                                    .build());
-
-        ConvictionDocuments convictionDocuments1 = documentsResponse.getConvictions().stream()
-            .filter(conviction -> conviction.getConvictionId().equals("2500295343"))
-            .findFirst().get();
-        assertThat(convictionDocuments1.getDocuments()).hasSize(6);
-        assertThat(convictionDocuments1.getDocuments())
-            .extracting("documentId")
-            .containsExactlyInAnyOrder("cc8bf04c-2f8c-4e72-a14b-ab6a5702bf59", "ec450eca-cf81-420d-8712-873a5df2274b",
-                "086bfb96-28a7-4b0a-80d5-7b877dd7bb75", "5058ca66-3751-4701-855a-86bf518d9392",
-                "44f37749-18b8-46ff-803a-150746f6d1bc", "b88547cf-7464-4cbc-b5f9-ebe2bafc19d9");
-
-        ConvictionDocuments convictionDocuments2 = documentsResponse.getConvictions().stream()
-            .filter(conviction -> conviction.getConvictionId().equals("2500295345"))
-            .findFirst().get();
-        assertThat(convictionDocuments2.getDocuments()).hasSize(9);
-        OffenderDocumentDetail preSentenceReport = convictionDocuments2.getDocuments().stream()
-            .filter(document -> document.getDocumentName().startsWith("shortFormatPreSentenceReport"))
-            .findFirst().get();
-        assertThat(preSentenceReport).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
-            .documentId("1d842fce-ec2d-45dc-ac9a-748d3076ca6b")
-            .documentName("shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf")
-            .author("Andy Marke")
-            .type(COURT_REPORT_DOCUMENT)
-            .extendedDescription("Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018")
-            .createdAt(LocalDateTime.of(2019, SEPTEMBER, 4, 0, 0, 0))
-            .subType(new KeyValue("CJF", "Pre-Sentence Report - Fast"))
-            .reportDocumentDates(new ReportDocumentDates(LocalDate.of(2018, SEPTEMBER, 4), LocalDate.of(2019, SEPTEMBER, 4), LocalDateTime.of(2018, FEBRUARY, 28, 0, 0, 0)))
-            .build());
-
-    }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/BreachServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/BreachServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.controller.model.BreachResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRestClient;
+import uk.gov.justice.probation.courtcaseservice.restclient.DocumentRestClient;
 import uk.gov.justice.probation.courtcaseservice.restclient.NsiRestClient;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper.NsiMapper;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsi;
@@ -16,6 +17,7 @@ import uk.gov.justice.probation.courtcaseservice.restclient.exception.NsiNotFoun
 import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 
 import java.util.Arrays;
+import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -32,11 +34,15 @@ class BreachServiceTest {
     @Mock
     private CommunityApiNsiType nsiType;
     @Mock
+    private GroupedDocuments groupedDocuments;
+    @Mock
     private Conviction conviction;
     @Mock
     private NsiRestClient nsiRestClient;
     @Mock
     private ConvictionRestClient convictionRestClient;
+    @Mock
+    private DocumentRestClient documentRestClient;
     @Mock
     private NsiMapper nsiMapper;
     @Mock
@@ -45,16 +51,17 @@ class BreachServiceTest {
 
     @BeforeEach
     public void setUp() {
-        breachService = new BreachService(nsiRestClient, convictionRestClient, nsiMapper, Arrays.asList("BRE", "BRES"));
+        breachService = new BreachService(nsiRestClient, convictionRestClient, documentRestClient, nsiMapper, Arrays.asList("BRE", "BRES"));
         when(nsi.getType()).thenReturn(nsiType);
         when(nsiRestClient.getNsiById(CRN, CONVICTION_ID, BREACH_ID)).thenReturn(Mono.just(nsi));
         when(convictionRestClient.getConviction(CRN, CONVICTION_ID)).thenReturn(Mono.just(conviction));
+        when(documentRestClient.getDocumentsByCrn(CRN)).thenReturn(Mono.just(groupedDocuments));
     }
 
     @Test
     public void whenGetBreachHasTypeBRE_thenReturnBreach() {
         when(nsiType.getCode()).thenReturn("BRE");
-        when(nsiMapper.breachOf(nsi, conviction)).thenReturn(expectedBreachResponse);
+        when(nsiMapper.breachOf(nsi, conviction, groupedDocuments)).thenReturn(expectedBreachResponse);
         BreachResponse actualBreachResponse = breachService.getBreach(CRN, CONVICTION_ID, BREACH_ID);
 
         assertThat(actualBreachResponse).isEqualTo(expectedBreachResponse);
@@ -63,7 +70,7 @@ class BreachServiceTest {
     @Test
     public void whenGetBreachHasTypeBRES_thenReturnBreach() {
         when(nsiType.getCode()).thenReturn("BRES");
-        when(nsiMapper.breachOf(nsi, conviction)).thenReturn(expectedBreachResponse);
+        when(nsiMapper.breachOf(nsi, conviction, groupedDocuments)).thenReturn(expectedBreachResponse);
         BreachResponse actualBreachResponse = breachService.getBreach(CRN, CONVICTION_ID, BREACH_ID);
 
         assertThat(actualBreachResponse).isEqualTo(expectedBreachResponse);

--- a/src/test/resources/http-request/rest-client.env.json
+++ b/src/test/resources/http-request/rest-client.env.json
@@ -3,7 +3,7 @@
     "host": "localhost:8080",
     "offenderCrn": "X320741",
     "convictionId": 2500295343,
-    "breach_breachId": 2500018597,
+    "breach_breachId": 2500018598,
     "breach_convictionId": 2500295345,
     "breach_crn": "X320741"
   },

--- a/src/test/resources/mocks/__files/offender-documents/GET_documents_success_X320741.json
+++ b/src/test/resources/mocks/__files/offender-documents/GET_documents_success_X320741.json
@@ -9,7 +9,6 @@
         "description": "PNC previous convictions"
       },
       "extendedDescription": "Previous convictions as of 01/09/2019",
-      "lastModifiedAt": "2019-09-10T15:06:08.219",
       "createdAt": "2019-09-10T00:00:00"
     },
     {
@@ -21,7 +20,8 @@
         "description": "Offender related"
       },
       "lastModifiedAt": "2019-09-10T15:06:08.219",
-      "createdAt": "2019-09-10T00:00:00"
+      "createdAt": "2019-09-10T00:00:00",
+      "parentPrimaryKeyId": 2500343964
     },
     {
       "id": "aeb43e06-a4a1-460f-9acf-e2495de84604",
@@ -32,7 +32,8 @@
         "description": "Offender related"
       },
       "lastModifiedAt": "2019-09-10T15:05:26.947",
-      "createdAt": "2019-09-10T00:00:00"
+      "createdAt": "2019-09-10T00:00:00",
+      "parentPrimaryKeyId": 2500343964
     },
     {
       "id": "b2d92238-215c-4d6d-b91c-208ea747087e",
@@ -44,7 +45,8 @@
       },
       "extendedDescription": "Address assessment on 02/09/2019",
       "lastModifiedAt": "2019-09-13T14:29:56.242",
-      "createdAt": "2019-09-13T00:00:00"
+      "createdAt": "2019-09-13T00:00:00",
+      "parentPrimaryKeyId": 2500066584
     },
     {
       "id": "5152b060-9650-4f22-9974-038a38590d9f",
@@ -56,7 +58,8 @@
       },
       "extendedDescription": "Personal contact of type GP with Good friend",
       "lastModifiedAt": "2019-09-13T16:24:28.802",
-      "createdAt": "2019-09-13T00:00:00"
+      "createdAt": "2019-09-13T00:00:00",
+      "parentPrimaryKeyId": 2500058493
     },
     {
       "id": "7ceda384-3624-4a62-849d-7c729b6d0dd1",
@@ -68,7 +71,8 @@
       },
       "extendedDescription": "Personal circumstance of AP - Medication in Posession  - Assessment started on 11/09/2019",
       "lastModifiedAt": "2019-09-12T16:10:18.064",
-      "createdAt": "2019-09-12T00:00:00"
+      "createdAt": "2019-09-12T00:00:00",
+      "parentPrimaryKeyId": 2500064995
     },
     {
       "id": "2b167448-31a5-45a5-85a5-dcdd4a783f1d",
@@ -80,7 +84,8 @@
       },
       "extendedDescription": "Non Statutory Intervention for OPD Community Pathway on 16/10/2019",
       "lastModifiedAt": "2019-10-17T09:50:13.186",
-      "createdAt": "2019-10-17T00:00:00"
+      "createdAt": "2019-10-17T00:00:00",
+      "parentPrimaryKeyId": 2500018819
     }
   ],
   "convictions": [
@@ -107,7 +112,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-04T11:52:35.298",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295343
         },
         {
           "id": "086bfb96-28a7-4b0a-80d5-7b877dd7bb75",
@@ -118,7 +124,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-05T00:00:00",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295343
         },
         {
           "id": "5058ca66-3751-4701-855a-86bf518d9392",
@@ -129,7 +136,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-04T11:52:57.054",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295343
         },
         {
           "id": "44f37749-18b8-46ff-803a-150746f6d1bc",
@@ -140,7 +148,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-19T15:45:16.432",
-          "createdAt": "2019-09-19T00:00:00"
+          "createdAt": "2019-09-19T00:00:00",
+          "parentPrimaryKeyId": 2500295343
         },
         {
           "id": "b88547cf-7464-4cbc-b5f9-ebe2bafc19d9",
@@ -152,7 +161,21 @@
           },
           "extendedDescription": "Referral for Mental Health Referral on 09/09/2019",
           "lastModifiedAt": "2019-09-13T15:41:34.04",
-          "createdAt": "2019-09-13T00:00:00"
+          "createdAt": "2019-09-13T00:00:00",
+          "parentPrimaryKeyId": 2500080018
+        },
+        {
+          "id": "4191eada-6e03-4bd8-b52d-9e050eefa745",
+          "documentName": "NSI.pdf.pdf",
+          "author": "Andy Marke",
+          "type": {
+            "code": "NSI_DOCUMENT",
+            "description": "Non Statutory Intervention related document"
+          },
+          "extendedDescription": "Non Statutory Intervention for Custody - Accredited Programme on 02/09/2019",
+          "lastModifiedAt": "2019-09-16T08:23:34.842",
+          "createdAt": "2019-09-16T00:00:00",
+          "parentPrimaryKeyId": 2500003903
         }
       ]
     },
@@ -179,7 +202,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-04T12:18:41.49",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295345
         },
         {
           "id": "e7d09bf6-b2e2-44eb-82be-2f561b575f1a",
@@ -190,7 +214,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-04T12:19:12.896",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295345
         },
         {
           "id": "424d3c35-12c5-41cf-8f0a-2e2eea46f45d",
@@ -201,7 +226,8 @@
             "description": "Sentence related"
           },
           "lastModifiedAt": "2019-09-04T12:19:34.156",
-          "createdAt": "2019-09-04T00:00:00"
+          "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500295345
         },
         {
           "id": "1d842fce-ec2d-45dc-ac9a-748d3076ca6b",
@@ -214,6 +240,7 @@
           "extendedDescription": "Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018",
           "lastModifiedAt": "2019-09-04T12:14:26.113",
           "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500079873,
           "subType": {
             "code": "CJF",
             "description": "Pre-Sentence Report - Fast"
@@ -235,6 +262,7 @@
           "extendedDescription": "Parole Assessment Report at Berwyn (HMP) requested on 05/09/2019",
           "lastModifiedAt": "2019-09-04T12:21:17.555",
           "createdAt": "2019-09-04T00:00:00",
+          "parentPrimaryKeyId": 2500078391,
           "subType": {
             "code": "PAR",
             "description": "Parole Assessment Report"
@@ -253,7 +281,8 @@
           },
           "extendedDescription": "Contact on 16/09/2019 for Case Conference - MAPPA",
           "lastModifiedAt": "2019-09-16T10:09:07.598",
-          "createdAt": "2019-09-16T00:00:00"
+          "createdAt": "2019-09-16T00:00:00",
+          "parentPrimaryKeyId": 2502721488
         },
         {
           "id": "f4d0fec8-c0bf-4297-9067-a5b410b69157",
@@ -264,19 +293,8 @@
             "description": "Case allocation document"
           },
           "lastModifiedAt": "2019-09-13T15:22:05.598",
-          "createdAt": "2019-09-13T00:00:00"
-        },
-        {
-          "id": "4191eada-6e03-4bd8-b52d-9e050eefa745",
-          "documentName": "NSI.pdf.pdf",
-          "author": "Andy Marke",
-          "type": {
-            "code": "NSI_DOCUMENT",
-            "description": "Non Statutory Intervention related document"
-          },
-          "extendedDescription": "Non Statutory Intervention for Custody - Accredited Programme on 02/09/2019",
-          "lastModifiedAt": "2019-09-16T08:23:34.842",
-          "createdAt": "2019-09-16T00:00:00"
+          "createdAt": "2019-09-13T00:00:00",
+          "parentPrimaryKeyId": 101579
         }
       ]
     }


### PR DESCRIPTION
Note the ticket refers to endpoint at 

`/offender/{crn}/breaches/{breachId}`

But existing BreachResponse was served up from below conviction, here 

`offender/{crn}/convictions/{convictionId}/breaches/{breachId}`

Assuming it was the latter. If it's the former then it's easy enough to add that.