### PR TITLE
:sparkles:  518 PUT by court and case no

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -53,13 +53,34 @@ public class CourtCaseController {
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
             @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not Found, if for example, the court code does not exist.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
         })
     @PutMapping(value = "/case/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
+    @Deprecated(forRemoval = true)
     public @ResponseBody
     CourtCaseResponse updateCase(@PathVariable(value = "id") String caseId, @Valid @RequestBody CourtCaseEntity courtCaseDetails) {
         return courtCaseResponseMapper.mapFrom(courtCaseService.createOrUpdateCase(caseId, courtCaseDetails));
+    }
+
+    @ApiOperation(value = "Saves and returns the court case entity data, by court and case number. ")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 201, message = "Created", response = CourtCaseResponse.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not Found, if for example, the court code does not exist.", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @PutMapping(value = "/court/{courtCode}/case/{caseNo}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public @ResponseBody
+    CourtCaseResponse updateCourtCaseNo(@PathVariable(value = "courtCode") String courtCode,
+                                        @PathVariable(value = "caseNo") String caseNo ,
+                                        @Valid @RequestBody CourtCaseEntity courtCaseDetails) {
+        return courtCaseResponseMapper.mapFrom(courtCaseService.createOrUpdateCase(courtCode, caseNo, courtCaseDetails));
     }
 
     @ApiOperation(value = "Gets case data for a court on a date.")

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.controller.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CourtCaseResponse {
     private LocalDateTime lastUpdated;
     private String caseId;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/AddressPropertiesEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/AddressPropertiesEntity.java
@@ -1,12 +1,15 @@
 package uk.gov.justice.probation.courtcaseservice.jpa.entity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-
-import java.io.Serializable;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AddressPropertiesEntity implements Serializable {
     private String line1;
     private String line2;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
@@ -3,24 +3,32 @@ package uk.gov.justice.probation.courtcaseservice.jpa.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-
-import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 @ApiModel(description = "Court Case")
 @Entity
 @AllArgsConstructor
-@NoArgsConstructor
 @Data
+@Builder
 @Table(name = "COURT_CASE")
 @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 public class CourtCaseEntity implements Serializable {
@@ -32,37 +40,39 @@ public class CourtCaseEntity implements Serializable {
     private Long id;
 
     @Column(name = "LAST_UPDATED", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
-    private LocalDateTime lastUpdated = LocalDateTime.now();
+    private LocalDateTime lastUpdated;
 
-    @Column(name = "CASE_ID")
+    @Column(name = "CASE_ID", nullable = false)
     private String caseId;
 
-    @Column(name = "CASE_NO")
+    @Column(name = "CASE_NO", nullable = false)
+    @Setter(AccessLevel.NONE)
     private String caseNo;
 
-    @Column(name = "COURT_CODE")
+    @Column(name = "COURT_CODE", nullable = false)
+    @Setter(AccessLevel.NONE)
     private String courtCode;
 
     @Column(name = "COURT_ROOM")
     private String courtRoom;
 
-    @Column(name = "SESSION_START_TIME")
+    @Column(name = "SESSION_START_TIME", nullable = false)
     private LocalDateTime sessionStartTime;
 
-    @Column(name = "PROBATION_STATUS")
+    @Column(name = "PROBATION_STATUS", nullable = false)
     private String probationStatus;
 
     @Column(name = "PREVIOUSLY_KNOWN_TERMINATION_DATE")
     private LocalDate previouslyKnownTerminationDate;
 
-    @Column(name = "SUSPENDED_SENTENCE_ORDER")
+    @Column(name = "SUSPENDED_SENTENCE_ORDER", nullable = false)
     private Boolean suspendedSentenceOrder;
 
-    @Column(name = "BREACH")
+    @Column(name = "BREACH", nullable = false)
     private Boolean breach;
 
     @OneToMany(mappedBy = "courtCase", cascade = CascadeType.ALL)
-    private List<OffenceEntity> offences = Collections.emptyList();
+    private List<OffenceEntity> offences;
 
     @Column(name = "DEFENDANT_NAME")
     private String defendantName;
@@ -91,6 +101,29 @@ public class CourtCaseEntity implements Serializable {
 
     @Column(name = "NATIONALITY_2")
     private String nationality2;
+
+    protected CourtCaseEntity() {
+        super();
+        this.lastUpdated = LocalDateTime.now();
+        this.offences = Collections.emptyList();
+    }
+
+
+    /**
+     * Construct with required identifying fields which form a unique key.
+     * Application should construct with this and do not need setter access for either field.
+     * @param courtCode
+     *             the court code
+     * @param caseNo
+     *              the case number
+     */
+    public CourtCaseEntity(String courtCode, String caseNo) {
+        super();
+        this.courtCode = courtCode;
+        this.caseNo = caseNo;
+        this.lastUpdated = LocalDateTime.now();
+        this.offences = Collections.emptyList();
+    }
 
     public CourtSession getSession() {
         return CourtSession.from(sessionStartTime);

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.jpa.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
@@ -9,9 +10,9 @@ import java.util.List;
 
 @Repository
 public interface CourtCaseRepository extends JpaRepository<CourtCaseEntity, Long> {
-    CourtCaseEntity findByCaseNo(String caseNo);
+    Optional<CourtCaseEntity> findByCourtCodeAndCaseNo(String courtCode, String caseNo);
 
     List<CourtCaseEntity> findByCourtCodeAndSessionStartTimeBetween(String courtCode, LocalDateTime start, LocalDateTime end);
 
-    CourtCaseEntity findByCaseId(String caseId);
+    Optional<CourtCaseEntity> findByCaseId(String caseId);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
@@ -21,9 +22,14 @@ public class CourtCaseService {
     private final CourtRepository courtRepository;
     private final CourtCaseRepository courtCaseRepository;
 
+    public CourtCaseService(CourtRepository courtRepository, CourtCaseRepository courtCaseRepository) {
+        super();
+        this.courtRepository = courtRepository;
+        this.courtCaseRepository = courtCaseRepository;
+    }
+
     private void checkCourtByCode(String courtCode) throws EntityNotFoundException {
-        CourtEntity courtEntity = courtRepository.findByCourtCode(courtCode);
-        if (courtEntity == null) {
+        if (courtRepository.findByCourtCode(courtCode) == null) {
             throw new EntityNotFoundException(String.format("Court %s not found", courtCode));
         }
     }
@@ -33,19 +39,11 @@ public class CourtCaseService {
         return courtCaseRepository.save(courtCaseEntity);
     }
 
-    public CourtCaseService(CourtRepository courtRepository, CourtCaseRepository courtCaseRepository) {
-        this.courtRepository = courtRepository;
-        this.courtCaseRepository = courtCaseRepository;
-    }
-
     public CourtCaseEntity getCaseByCaseNumber(String courtCode, String caseNo) throws EntityNotFoundException {
         checkCourtByCode(courtCode);
-        CourtCaseEntity courtCaseEntity = courtCaseRepository.findByCaseNo(caseNo);
-        if (courtCaseEntity == null) {
-            throw new EntityNotFoundException(String.format("Case %s not found", caseNo));
-        }
         log.info("Court case requested for court {} for case {}", courtCode, caseNo);
-        return courtCaseEntity;
+        return courtCaseRepository.findByCourtCodeAndCaseNo(courtCode, caseNo)
+            .orElseThrow(() -> new EntityNotFoundException(String.format("Case %s not found for court %s", caseNo, courtCode)));
     }
 
     public CourtCaseEntity createOrUpdateCase(String caseId, CourtCaseEntity courtCaseEntity) throws EntityNotFoundException, InputMismatchException {
@@ -55,27 +53,17 @@ public class CourtCaseService {
             throw new InputMismatchException(String.format("Case ID %s does not match with %s", caseId, bodyCaseId));
         }
 
-        linkOffencesToCourtCase(courtCaseEntity);
+        return processAndSave(courtCaseEntity, courtCaseRepository.findByCaseId(caseId));
+    }
 
-        CourtCaseEntity existingCase = courtCaseRepository.findByCaseId(caseId);
-
-        if (existingCase == null) {
-            return createCase(courtCaseEntity);
+    public CourtCaseEntity createOrUpdateCase(String courtCode, String caseNo, CourtCaseEntity courtCaseEntity) throws EntityNotFoundException, InputMismatchException {
+        checkCourtByCode(courtCaseEntity.getCourtCode());
+        if (!caseNo.equals(courtCaseEntity.getCaseNo()) || !courtCode.equals(courtCaseEntity.getCourtCode()) ) {
+            throw new InputMismatchException(String.format("Case No %s and Court Code %s do not match with values from body %s and %s",
+                caseNo, courtCode, courtCaseEntity.getCaseNo(), courtCaseEntity.getCourtCode()));
         }
 
-        existingCase.setCaseNo(courtCaseEntity.getCaseNo());
-        existingCase.setCourtCode(courtCaseEntity.getCourtCode());
-        existingCase.setCourtRoom(courtCaseEntity.getCourtRoom());
-        existingCase.setProbationStatus(courtCaseEntity.getProbationStatus());
-        existingCase.setSessionStartTime(courtCaseEntity.getSessionStartTime());
-        existingCase.setPreviouslyKnownTerminationDate(courtCaseEntity.getPreviouslyKnownTerminationDate());
-        existingCase.setSuspendedSentenceOrder(courtCaseEntity.getSuspendedSentenceOrder());
-        existingCase.setBreach(courtCaseEntity.getBreach());
-        existingCase.setDefendantName(courtCaseEntity.getDefendantName());
-        existingCase.setDefendantAddress(courtCaseEntity.getDefendantAddress());
-
-        log.info("Court case updated for case {}", courtCaseEntity.getCaseNo());
-        return courtCaseRepository.save(existingCase);
+        return processAndSave(courtCaseEntity,  courtCaseRepository.findByCourtCodeAndCaseNo(courtCode, caseNo));
     }
 
     public List<CourtCaseEntity> filterCasesByCourtAndDate(String courtCode, LocalDate date) {
@@ -86,6 +74,36 @@ public class CourtCaseService {
         }
         LocalDateTime start = LocalDateTime.of(date, LocalTime.MIDNIGHT);
         return courtCaseRepository.findByCourtCodeAndSessionStartTimeBetween(court.getCourtCode(), start, start.plusDays(1));
+    }
+
+    private CourtCaseEntity processAndSave(CourtCaseEntity courtCaseEntity, Optional<CourtCaseEntity> existingCourtCaseEntity) {
+
+        linkOffencesToCourtCase(courtCaseEntity);
+
+        if (existingCourtCaseEntity.isEmpty()) {
+            return createCase(courtCaseEntity);
+        }
+
+        return updateAndSave(existingCourtCaseEntity.get(), courtCaseEntity);
+    }
+
+    private CourtCaseEntity updateAndSave(CourtCaseEntity existingCase, CourtCaseEntity courtCaseEntity) {
+        // We have checked and matched court ode and case no. They are immutable fields. No need to update.
+        existingCase.setCourtRoom(courtCaseEntity.getCourtRoom());
+        existingCase.setProbationStatus(courtCaseEntity.getProbationStatus());
+        existingCase.setSessionStartTime(courtCaseEntity.getSessionStartTime());
+        existingCase.setPreviouslyKnownTerminationDate(courtCaseEntity.getPreviouslyKnownTerminationDate());
+        existingCase.setSuspendedSentenceOrder(courtCaseEntity.getSuspendedSentenceOrder());
+        existingCase.setBreach(courtCaseEntity.getBreach());
+        existingCase.setDefendantName(courtCaseEntity.getDefendantName());
+        existingCase.setDefendantAddress(courtCaseEntity.getDefendantAddress());
+        existingCase.setPnc(courtCaseEntity.getPnc());
+        existingCase.setListNo(courtCaseEntity.getListNo());
+        existingCase.setNationality1(courtCaseEntity.getNationality1());
+        existingCase.setNationality2(courtCaseEntity.getNationality2());
+        existingCase.setLastUpdated(LocalDateTime.now());
+        log.info("Court case updated for case no {}", courtCaseEntity.getCaseNo());
+        return courtCaseRepository.save(existingCase);
     }
 
     private void linkOffencesToCourtCase(CourtCaseEntity courtCaseEntity) {

--- a/src/main/resources/db/migration/courtcase/V108__make_unique_key_for_court_and_case_no_court_case.sql
+++ b/src/main/resources/db/migration/courtcase/V108__make_unique_key_for_court_and_case_no_court_case.sql
@@ -1,0 +1,5 @@
+ALTER TABLE COURT_CASE DROP CONSTRAINT court_case_case_no_idempotent;
+
+CREATE UNIQUE INDEX court_case_court_case_uq ON COURT_CASE (COURT_CODE, CASE_NO);
+
+ALTER TABLE COURT_CASE ADD CONSTRAINT court_case_uq UNIQUE USING INDEX court_case_court_case_uq;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -1,0 +1,393 @@
+package uk.gov.justice.probation.courtcaseservice.controller;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
+@Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
+public class CourtCaseControllerPutIntTest {
+
+    /* before-test.sql sets up a court case in the database */
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Autowired
+    CourtCaseRepository courtCaseRepository;
+
+    private static final String CRN = "X320741";
+    private static final String PNC = "A/1234560BA";
+    private static final String COURT_ROOM = "1";
+    private static final String LIST_NO = "1st";
+    private static final String DEFENDANT_SEX = "M";
+    private static final String NATIONALITY_1 = "British";
+    private static final String NATIONALITY_2 = "Polish";
+    private static final String COURT_CODE = "SHF";
+    private static final AddressPropertiesEntity ADDRESS = new AddressPropertiesEntity("27", "Elm Place", "ad21 5dr", "Bangor", null, null);
+    private static final String PROBATION_STATUS = "Previously known";
+    private static final String NOT_FOUND_COURT_CODE = "LPL";
+    private static final String DEFENDANT_NAME = "JTEST";
+    private static final LocalDate DEFENDANT_DOB = LocalDate.of(1958, 12, 14);
+    private static final LocalDateTime sessionStartTime = LocalDateTime.of(2019, 12, 14, 9, 0);
+
+    @Value("classpath:integration/request/PUT_courtCase_success.json")
+    private Resource caseDetailsResource;
+    private String caseDetailsJson;
+
+    /** NEW values match those from JSON file incoming. */
+    private static final String JSON_CASE_NO = "1700028914";
+    private static final String JSON_CASE_ID = "654321";
+
+    @Before
+    public void setup() throws IOException {
+        caseDetailsJson = Files.readString(caseDetailsResource.getFile().toPath());
+        TestConfig.configureRestAssuredForIntTest(port);
+    }
+
+    @Test
+    public void whenCreateCourtCaseWithUnknownCourt_ThenRaise404() {
+
+        CourtCaseEntity courtCaseEntity = createCaseDetails(NOT_FOUND_COURT_CODE, JSON_CASE_NO, JSON_CASE_ID);
+
+        ErrorResponse result = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(courtCaseEntity)
+                .when()
+                .put("/case/" + JSON_CASE_ID)
+                .then()
+                .statusCode(404)
+                .extract()
+                .body()
+                .as(ErrorResponse.class);
+
+        assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+        assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+        assertThat(result.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    public void whenCreateCourtCaseWithMismatchCaseId_ThenRaise500() {
+        String mismatchCaseId = "000000";
+        CourtCaseEntity courtCaseEntity = createCaseDetails(COURT_CODE, JSON_CASE_NO, JSON_CASE_ID);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(courtCaseEntity)
+                .when()
+                .put("/case/" + mismatchCaseId)
+                .then()
+                .statusCode(500)
+                .body("message", equalTo("Case ID " + mismatchCaseId + " does not match with " + JSON_CASE_ID));
+    }
+
+    @Test
+    public void whenCreateCaseDataById_ThenCreateNewRecord() {
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(caseDetailsJson)
+                .when()
+                .put("/case/" + JSON_CASE_ID)
+                .then()
+                .statusCode(201)
+                .body("caseId", equalTo(JSON_CASE_ID))
+                .body("caseNo", equalTo(JSON_CASE_NO))
+                .body("crn", equalTo(CRN))
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("courtRoom", equalTo(COURT_ROOM))
+                .body("probationStatus", equalTo(PROBATION_STATUS))
+                .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
+                .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                .body("suspendedSentenceOrder", equalTo(true))
+                .body("breach", equalTo(true))
+                .body("defendantName", equalTo(DEFENDANT_NAME))
+                .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
+                .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
+                .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
+                .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
+                .body("defendantAddress.line4", equalTo(null))
+                .body("defendantAddress.line5", equalTo(null))
+                .body("offences", hasSize(2))
+                .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+                .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+                .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+                .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+                .body("pnc", equalTo(PNC))
+                .body("listNo", equalTo(LIST_NO))
+                .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                .body("defendantSex", equalTo(DEFENDANT_SEX))
+                .body("nationality1", equalTo(NATIONALITY_1))
+                .body("nationality2", equalTo(NATIONALITY_2))
+        ;
+
+    }
+
+    @Test
+    public void whenUpdateCaseDataById_ThenUpdate() {
+
+        createCase();
+
+        String newCourtRoom = "2";
+        String updatedJson = caseDetailsJson.replace("\"courtRoom\": \"1\"", "\"courtRoom\": \"" + newCourtRoom + "\"");
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put("/case/" + JSON_CASE_ID)
+                .then()
+                .statusCode(201)
+                .body("caseId", equalTo(JSON_CASE_ID))
+                .body("caseNo", equalTo(JSON_CASE_NO))
+                .body("crn", equalTo(CRN))
+                .body("pnc", equalTo(PNC))
+                .body("listNo", equalTo(LIST_NO))
+                .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                .body("defendantSex", equalTo(DEFENDANT_SEX))
+                .body("nationality1", equalTo(NATIONALITY_1))
+                .body("nationality2", equalTo(NATIONALITY_2))
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("courtRoom", equalTo(newCourtRoom))
+                .body("probationStatus", equalTo(PROBATION_STATUS))
+                .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
+                .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                .body("suspendedSentenceOrder", equalTo(true))
+                .body("breach", equalTo(true))
+                .body("defendantName", equalTo(DEFENDANT_NAME))
+                .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
+                .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
+                .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
+                .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
+                .body("defendantAddress.line4", equalTo(null))
+                .body("defendantAddress.line5", equalTo(null))
+                .body("offences", hasSize(2))
+                .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+                .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+                .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+                .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+        ;
+
+    }
+
+    @Test
+    public void whenCourtCaseCreated_thenOffenceSequenceNumberShouldBeReflectedInResponse() {
+        var modifiedJson = caseDetailsJson
+            .replace("\"sequenceNumber\": 1", "\"sequenceNumber\": 4")
+            .replace("\"sequenceNumber\": 2", "\"sequenceNumber\": 3");
+
+        given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(modifiedJson)
+            .when()
+            .put("/case/" + JSON_CASE_ID)
+            .then()
+            .statusCode(201)
+            .body("offences", hasSize(2))
+            .body("offences[0].offenceTitle", equalTo("Theft from a different shop"))
+            .body("offences[1].offenceTitle", equalTo("Theft from a shop"))
+        ;
+
+    }
+
+    @Test
+    public void whenCreateCaseDataByCourtAndCaseNo_ThenCreateNewRecord() {
+
+        given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(caseDetailsJson)
+        .when()
+            .put(String.format("/court/%s/case/%s", COURT_CODE, JSON_CASE_NO))
+        .then()
+            .statusCode(201)
+            .body("caseId", equalTo(JSON_CASE_ID))
+            .body("caseNo", equalTo(JSON_CASE_NO))
+            .body("crn", equalTo(CRN))
+            .body("courtCode", equalTo(COURT_CODE))
+            .body("courtRoom", equalTo(COURT_ROOM))
+            .body("probationStatus", equalTo(PROBATION_STATUS))
+            .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
+            .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("suspendedSentenceOrder", equalTo(true))
+            .body("breach", equalTo(true))
+            .body("defendantName", equalTo(DEFENDANT_NAME))
+            .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
+            .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
+            .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
+            .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
+            .body("defendantAddress.line4", equalTo(null))
+            .body("defendantAddress.line5", equalTo(null))
+            .body("offences", hasSize(2))
+            .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+            .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+            .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+            .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+            .body("pnc", equalTo(PNC))
+            .body("listNo", equalTo(LIST_NO))
+            .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("defendantSex", equalTo(DEFENDANT_SEX))
+            .body("nationality1", equalTo(NATIONALITY_1))
+            .body("nationality2", equalTo(NATIONALITY_2))
+        ;
+
+    }
+
+    @Test
+    public void whenUpdateCaseDataByCourtAndCaseNo_ThenUpdate() {
+
+        createCase();
+
+        String updatedJson = caseDetailsJson.replace("\"courtRoom\": \"1\"", "\"courtRoom\": \"2\"");
+
+        given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(updatedJson)
+        .when()
+            .put(String.format("/court/%s/case/%s", COURT_CODE, JSON_CASE_NO))
+        .then()
+            .statusCode(201)
+            .body("caseId", equalTo(JSON_CASE_ID))
+            .body("caseNo", equalTo(JSON_CASE_NO))
+            .body("courtCode", equalTo(COURT_CODE))
+            .body("crn", equalTo(CRN))
+            .body("pnc", equalTo(PNC))
+            .body("listNo", equalTo(LIST_NO))
+            .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("defendantSex", equalTo(DEFENDANT_SEX))
+            .body("nationality1", equalTo(NATIONALITY_1))
+            .body("nationality2", equalTo(NATIONALITY_2))
+            .body("courtRoom", equalTo("2"))
+            .body("probationStatus", equalTo(PROBATION_STATUS))
+            .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
+            .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("suspendedSentenceOrder", equalTo(true))
+            .body("breach", equalTo(true))
+            .body("defendantName", equalTo(DEFENDANT_NAME))
+            .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
+            .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
+            .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
+            .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
+            .body("defendantAddress.line4", equalTo(null))
+            .body("defendantAddress.line5", equalTo(null))
+            .body("offences", hasSize(2))
+            .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+            .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+            .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+            .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+        ;
+
+    }
+
+    @Test
+    public void whenCreateCourtCaseByCourtAndCaseWithUnknownCourt_ThenRaise404() {
+
+        CourtCaseEntity courtCaseEntity = createCaseDetails(NOT_FOUND_COURT_CODE, JSON_CASE_NO, JSON_CASE_ID);
+
+        ErrorResponse result = given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(courtCaseEntity)
+            .when()
+            .put(String.format("/court/%s/case/%s", NOT_FOUND_COURT_CODE, JSON_CASE_NO))
+            .then()
+            .statusCode(404)
+            .extract()
+            .body()
+            .as(ErrorResponse.class);
+
+        assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+        assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+        assertThat(result.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    public void whenCreateCourtCaseByCourtAndCaseWithMismatchCourt_ThenRaise500() {
+
+        CourtCaseEntity courtCaseEntity = createCaseDetails(COURT_CODE, JSON_CASE_NO, JSON_CASE_ID);
+
+        given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(courtCaseEntity)
+            .when()
+            .put(String.format("/court/%s/case/%s", "NWS", "99999"))
+            .then()
+            .statusCode(500)
+            .body("message", equalTo("Case No 99999 and Court Code NWS do not match with values from body 1700028914 and SHF"))
+        ;
+
+    }
+
+    private CourtCaseEntity createCaseDetails(String courtCode, String caseNo, String caseId) {
+
+        CourtCaseEntity caseDetails = new CourtCaseEntity(courtCode, caseNo);
+        caseDetails.setCaseId(caseId);
+        caseDetails.setCourtRoom("1");
+        caseDetails.setSessionStartTime(LocalDateTime.now());
+        caseDetails.setProbationStatus(PROBATION_STATUS);
+        caseDetails.setLastUpdated(LocalDateTime.now());
+        caseDetails.setPreviouslyKnownTerminationDate(LocalDate.of(2010, 1, 1));
+        caseDetails.setSuspendedSentenceOrder(true);
+        caseDetails.setBreach(true);
+        caseDetails.setDefendantName(DEFENDANT_NAME);
+        caseDetails.setDefendantAddress(ADDRESS);
+        caseDetails.setPnc(PNC);
+        caseDetails.setListNo(LIST_NO);
+        caseDetails.setDefendantDob(DEFENDANT_DOB);
+        caseDetails.setDefendantSex(DEFENDANT_SEX);
+        caseDetails.setNationality1(NATIONALITY_1);
+        caseDetails.setNationality2(NATIONALITY_2);
+        return caseDetails;
+    }
+
+    private void createCase() {
+        given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(caseDetailsJson)
+            .when()
+            .put("/case/" + JSON_CASE_ID)
+            .then()
+            .statusCode(201);
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
@@ -30,9 +30,9 @@ public class CourtCaseControllerTest {
     private CourtCaseResponseMapper courtCaseResponseMapper;
 
     private CourtCaseController courtCaseController;
-    private CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
-    private CourtCaseResponse courtCaseResponse = new CourtCaseResponse();
-    private CourtCaseEntity courtCaseUpdate = new CourtCaseEntity();
+    private final CourtCaseEntity courtCaseEntity = new CourtCaseEntity(COURT_CODE, CASE_NO);
+    private final CourtCaseResponse courtCaseResponse = new CourtCaseResponse();
+    private final CourtCaseEntity courtCaseUpdate = new CourtCaseEntity(COURT_CODE, CASE_NO);
 
     @Before
     public void setUp() {
@@ -53,6 +53,14 @@ public class CourtCaseControllerTest {
     public void updateCase_shouldReturnCourtCaseResponse() {
         CourtCaseResponse courtCase = courtCaseController.updateCase(CASE_ID, courtCaseUpdate);
         assertThat(courtCase).isEqualTo(courtCaseResponse);
+    }
+
+    @Test
+    public void updateCaseByCourtAndCaseNo_shouldReturnCourtCaseResponse() {
+        when(courtCaseService.createOrUpdateCase(COURT_CODE, CASE_NO, courtCaseUpdate)).thenReturn(courtCaseEntity);
+
+        CourtCaseResponse courtCase = courtCaseController.updateCourtCaseNo(COURT_CODE, CASE_NO, courtCaseUpdate);
+        assertThat(courtCase).isSameAs(courtCaseResponse);
     }
 
     @Test

--- a/src/test/resources/http-request/court-case-ctrl.rest
+++ b/src/test/resources/http-request/court-case-ctrl.rest
@@ -68,11 +68,65 @@ Content-Type: application/json
   "nationality2": null
 }
 
+###
+# Update a case by court and code
+PUT http://{{host}}/court/{{courtCode}}/case/{{caseNo}}
+Content-Type: application/json
+
+{
+  "lastUpdated": "2019-12-14T09:00:00",
+  "caseId": "1168460",
+  "caseNo": "1600028974",
+  "crn": "X320744",
+  "pnc": "D/1234560BC",
+  "listNo": "2nd",
+  "courtCode": "SHF",
+  "courtRoom": "1",
+  "sessionStartTime": "2020-01-13T09:00:00",
+  "probationStatus": "Current",
+  "previouslyKnownTerminationDate": null,
+  "suspendedSentenceOrder": true,
+  "breach": true,
+  "offences": [],
+  "defendantName": "Mr Dylan Adam Armstrong",
+  "defendantAddress": {
+    "line1": "27",
+    "line2": "Elm Place",
+    "postcode": "ad21 5dr",
+    "line3": "Bangor"
+  },
+  "defendantSex": "M",
+  "defendantDob": "1957-12-12",
+  "nationality1": "British"
+}
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 201, "Response status is not 201");
+    });
+
+    client.test("Response content-type is json", function() {
+        var type = response.contentType.mimeType;
+        client.assert(type === "application/json", "Expected 'application/json' but received '" + type + "'");
+    });
+%}
+
 ### COURT AND CASE ENDPOINT
 ### Get by court and case
 # Gives 200 because it's all known
-GET http://{{host}}/court/SHF/case/1600028974
+GET http://{{host}}/court/{{courtCode}}/case/{{caseNo}}
 Accept: application/json
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+
+    client.test("Response content-type is json", function() {
+        var type = response.contentType.mimeType;
+        client.assert(type === "application/json", "Expected 'application/json' but received '" + type + "'");
+    });
+%}
 
 ###
 # Gives 404 because case no is unknown

--- a/src/test/resources/http-request/rest-client.env.json
+++ b/src/test/resources/http-request/rest-client.env.json
@@ -1,6 +1,8 @@
 {
   "local": {
     "host": "localhost:8080",
+    "courtCode": "SHF",
+    "caseNo": 1600028974,
     "offenderCrn": "X320741",
     "convictionId": 2500295343,
     "breach_breachId": 2500018598,

--- a/src/test/resources/integration/request/PUT_courtCase_success.json
+++ b/src/test/resources/integration/request/PUT_courtCase_success.json
@@ -35,7 +35,6 @@
     "line4": null,
     "line5": null
   },
-  "session": "MORNING",
   "defendantDob": "1958-12-14",
   "defendantSex": "M",
   "nationality1": "British",


### PR DESCRIPTION
The PUT to create / update by case ID is deprecated. We now update by what we are thinking of as our unique business key (court code and case no). The headline of this change is a new method that does pretty much the same as the PUT by case ID. Other associated changes

- make a unique key of court code / case no. These fields should be immutable once saved so no setters on the Entity object
- case no is no longer unique by itself