### PR TITLE
Fix flaky tests

### DIFF
--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/BaseIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/BaseIntTest.java
@@ -1,0 +1,38 @@
+package uk.gov.justice.probation.courtcaseservice;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@EnableRetry
+public class BaseIntTest {
+    @ClassRule
+    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
+            .port(WIREMOCK_PORT)
+            .usingFilesUnderClasspath("mocks"));
+
+    @LocalServerPort
+    protected int port;
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        TestConfig.configureRestAssuredForIntTest(port);
+    }
+}
+
+

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/RetryService.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/RetryService.java
@@ -1,9 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice;
 
-import static java.time.Duration.ofSeconds;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
-
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
@@ -13,16 +9,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import static java.time.Duration.ofSeconds;
+import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
+
 @Service
 public class RetryService {
 
     private static final Logger log = LoggerFactory.getLogger(RetryService.class);
-
-    private final WebClient webClient;
-
-    public RetryService() {
-        this.webClient = WebClient.create("http://localhost:" + WIREMOCK_PORT + "/");
-    }
 
     /**
      * Calls a simple wiremock stub. It's a workaround to a problem described here.
@@ -32,21 +25,22 @@ public class RetryService {
      *              if the method fails to call wiremock stub with 200 status
      */
     @Retryable(value = {Exception.class}, maxAttempts = 5, backoff = @Backoff(delay = 1000))
-    public void tryWireMockStub() throws Exception {
+    public static void tryWireMockStub() throws Exception {
+        var webClient = WebClient.create("http://localhost:" + WIREMOCK_PORT + "/");
         log.debug("Starting call to ... WireMock readiness stub");
-        Optional<ClientResponse> clientResponse = webClient.method(HttpMethod.GET)
+        var clientResponse = webClient.method(HttpMethod.GET)
                                                             .uri("/readiness/wiremock")
                                                             .exchange()
                                                             .blockOptional(ofSeconds(1));
 
-        if (!clientResponse.map(this::checkCode).orElse(Boolean.FALSE)) {
+        if (!clientResponse.map(RetryService::checkCode).orElse(Boolean.FALSE)) {
             log.warn("Call to {} failed.", "/readiness/wiremock");
             throw new Exception("Wiremock not ready!");
         }
         log.debug("Call to WireMock readiness stub completed with response :{}", clientResponse.get().bodyToMono(String.class).block(ofSeconds(1)));
     }
 
-    private boolean checkCode(ClientResponse clientResponse) {
+    private static boolean checkCode(ClientResponse clientResponse) {
         return clientResponse.statusCode().is2xxSuccessful();
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.RetryService;
 import uk.gov.justice.probation.courtcaseservice.TestConfig;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 
@@ -61,6 +63,12 @@ public class CourtCaseControllerIntTest {
     public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
             .port(WIREMOCK_PORT)
             .usingFilesUnderClasspath("mocks"));
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
+
     @Before
     public void setup() {
         TestConfig.configureRestAssuredForIntTest(port);

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -1,21 +1,12 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 
 import java.time.LocalDate;
@@ -23,7 +14,6 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -32,19 +22,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-public class CourtCaseControllerIntTest {
+public class CourtCaseControllerIntTest extends uk.gov.justice.probation.courtcaseservice.BaseIntTest {
     public static final String KEY_ID = "mock-key";
-
-    @LocalServerPort
-    private int port;
 
     @Autowired
     ObjectMapper mapper;
@@ -58,21 +42,6 @@ public class CourtCaseControllerIntTest {
     private static final String NOT_FOUND_COURT_CODE = "LPL";
     private static final String DEFENDANT_NAME = "JTEST";
     private final LocalDateTime now = LocalDateTime.now();
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
-    @Before
-    public void setup() {
-        TestConfig.configureRestAssuredForIntTest(port);
-    }
 
     @Test
     public void cases_shouldGetCaseListWhenCasesExist() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.restassured.http.ContentType;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.RetryService;
 import uk.gov.justice.probation.courtcaseservice.TestConfig;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
@@ -84,6 +86,11 @@ public class CourtCaseControllerPutIntTest {
     public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
             .port(WIREMOCK_PORT)
             .usingFilesUnderClasspath("mocks"));
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
 
     @Before
     public void setup() throws IOException {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -1,35 +1,26 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.restassured.http.ContentType;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -38,20 +29,14 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-public class CourtCaseControllerPutIntTest {
+public class CourtCaseControllerPutIntTest extends BaseIntTest {
 
     /* before-test.sql sets up a court case in the database */
-
-    @LocalServerPort
-    private int port;
 
     @Autowired
     ObjectMapper mapper;
@@ -82,20 +67,10 @@ public class CourtCaseControllerPutIntTest {
     private static final String JSON_CASE_NO = "1700028914";
     private static final String JSON_CASE_ID = "654321";
 
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         caseDetailsJson = Files.readString(caseDetailsResource.getFile().toPath());
-        TestConfig.configureRestAssuredForIntTest(port);
+        super.setup();
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtControllerIntTest.java
@@ -1,37 +1,25 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.restassured.http.ContentType;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtEntity;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-public class CourtControllerIntTest {
+public class CourtControllerIntTest extends BaseIntTest {
 
 
     private static final String COURT_CODE = "FOO";
@@ -41,26 +29,8 @@ public class CourtControllerIntTest {
                     "\"courtCode\": \"" + COURT_CODE + "\"" +
                     "}";
 
-    @LocalServerPort
-    private int port;
-
     @Autowired
     ObjectMapper mapper;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
-    @Before
-    public void setup() {
-        TestConfig.configureRestAssuredForIntTest(port);
-    }
 
     @Test
     public void whenCourtCreated_thenReturnSuccess() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtControllerIntTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.restassured.http.ContentType;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.RetryService;
 import uk.gov.justice.probation.courtcaseservice.TestConfig;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtEntity;
 
@@ -49,6 +51,11 @@ public class CourtControllerIntTest {
     public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
             .port(WIREMOCK_PORT)
             .usingFilesUnderClasspath("mocks"));
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
 
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -3,11 +3,11 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -49,20 +49,20 @@ public class OffenderControllerIntTest {
     @LocalServerPort
     private int port;
 
-    @Autowired
-    private RetryService retryService;
-
-    @Before
-    public void setUp() throws Exception {
-        TestConfig.configureRestAssuredForIntTest(port);
-
-        retryService.tryWireMockStub();
-    }
-
     @ClassRule
     public static  final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-                                                                .port(WIREMOCK_PORT)
-                                                                .usingFilesUnderClasspath("mocks"));
+            .port(WIREMOCK_PORT)
+            .usingFilesUnderClasspath("mocks"));
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
+
+    @Before
+    public void setUp() {
+        TestConfig.configureRestAssuredForIntTest(port);
+    }
 
     @Test
     public void givenOffenderDoesNotExist_whenCallMadeToGetProbationRecord_thenReturnNotFound() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -1,27 +1,18 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,36 +24,15 @@ import static org.springframework.http.HttpHeaders.ACCEPT_RANGES;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpHeaders.LAST_MODIFIED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@EnableRetry
-@ActiveProfiles(profiles = "test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "org.apache.catalina.connector.RECYCLE_FACADES=true")
-public class OffenderControllerIntTest {
+public class OffenderControllerIntTest extends BaseIntTest {
 
     private static final String GET_DOCUMENT_PATH = "/offender/%s/documents/%s";
 
     private static final String KNOWN_CRN = "X320741";
-
-    @LocalServerPort
-    private int port;
-
-    @ClassRule
-    public static  final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
-    @Before
-    public void setUp() {
-        TestConfig.configureRestAssuredForIntTest(port);
-    }
 
     @Test
     public void givenOffenderDoesNotExist_whenCallMadeToGetProbationRecord_thenReturnNotFound() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_ConvictionIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_ConvictionIntTest.java
@@ -1,22 +1,15 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.application.FeatureFlags;
 import uk.gov.justice.probation.courtcaseservice.controller.model.AttendanceResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.AttendanceResponse.ContactTypeDetail;
@@ -28,10 +21,8 @@ import uk.gov.justice.probation.courtcaseservice.service.model.UnpaidWork;
 import java.time.LocalDate;
 import java.time.Month;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRestClientIntTest.CRN;
 import static uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRestClientIntTest.SOME_CONVICTION_ID;
 import static uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRestClientIntTest.SOME_SENTENCE_ID;
@@ -39,34 +30,19 @@ import static uk.gov.justice.probation.courtcaseservice.restclient.ConvictionRes
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@EnableRetry
-@ActiveProfiles(profiles = "test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "org.apache.catalina.connector.RECYCLE_FACADES=true")
-public class OffenderController_ConvictionIntTest {
+public class OffenderController_ConvictionIntTest extends BaseIntTest {
 
     private static final String PATH = "/offender/%s/convictions/%s/sentences/%s";
 
     @Autowired
     private FeatureFlags featureFlags;
 
-    @LocalServerPort
-    private int port;
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
+        super.setup();
         featureFlags.setFlagValue("fetch-sentence-data",true);
-        TestConfig.configureRestAssuredForIntTest(port);
     }
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-        .port(WIREMOCK_PORT)
-        .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void whenCallMadeToGetSentenceKnownCrnAndConvictionId() {
@@ -112,10 +88,10 @@ public class OffenderController_ConvictionIntTest {
                 .custodialType(KeyValue.builder().code("P").description("Post Sentence Supervision").build())
                 .sentenceDescription("CJA - Intermediate Public Prot.")
                 .mainOffenceDescription("Common assault and battery - 10501")
-                .sentenceDate(LocalDate.of(2018, Month.DECEMBER, 03))
-                .actualReleaseDate(LocalDate.of(2019, Month.JULY, 03))
-                .licenceExpiryDate(LocalDate.of(2019, Month.NOVEMBER, 03))
-                .pssEndDate(LocalDate.of(2020, Month.JUNE, 03))
+                .sentenceDate(LocalDate.of(2018, Month.DECEMBER, 3))
+                .actualReleaseDate(LocalDate.of(2019, Month.JULY, 3))
+                .licenceExpiryDate(LocalDate.of(2019, Month.NOVEMBER, 3))
+                .pssEndDate(LocalDate.of(2020, Month.JUNE, 3))
                 .length(11)
                 .lengthUnits("Months")
                 .build());

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_ConvictionIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_ConvictionIntTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,18 +49,18 @@ public class OffenderController_ConvictionIntTest {
     @Autowired
     private FeatureFlags featureFlags;
 
-    @Autowired
-    private RetryService retryService;
-
     @LocalServerPort
     private int port;
 
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
+
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         featureFlags.setFlagValue("fetch-sentence-data",true);
         TestConfig.configureRestAssuredForIntTest(port);
-
-        retryService.tryWireMockStub();
     }
 
     @ClassRule

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
@@ -3,10 +3,10 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
@@ -52,14 +52,14 @@ public class OffenderMatchesControllerIntTest {
     @LocalServerPort
     private int port;
 
-    @Autowired
-    private RetryService retryService;
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        RetryService.tryWireMockStub();
+    }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestConfig.configureRestAssuredForIntTest(port);
-
-        retryService.tryWireMockStub();
     }
 
     @ClassRule

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
@@ -1,40 +1,28 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.RetryService;
-import uk.gov.justice.probation.courtcaseservice.TestConfig;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
-@EnableRetry
-@ActiveProfiles(profiles = "test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "org.apache.catalina.connector.RECYCLE_FACADES=true")
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-public class OffenderMatchesControllerIntTest {
+public class OffenderMatchesControllerIntTest extends BaseIntTest {
 
     public static final String SINGLE_EXACT_MATCH_BODY = "{\n" +
             "    \"matches\": [\n" +
@@ -49,23 +37,6 @@ public class OffenderMatchesControllerIntTest {
             "        }\n" +
             "    ]\n" +
             "}";
-    @LocalServerPort
-    private int port;
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
-        RetryService.tryWireMockStub();
-    }
-
-    @Before
-    public void setUp() {
-        TestConfig.configureRestAssuredForIntTest(port);
-    }
-
-    @ClassRule
-    public static  final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-                                                                .port(WIREMOCK_PORT)
-                                                                .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void givenCaseExists_whenPostMadeToOffenderMatches_thenReturn201CreatedWithValidLocation() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/PingControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/PingControllerIntTest.java
@@ -1,30 +1,16 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.configureRestAssuredForIntTest;
 
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles(profiles = "test")
-public class PingControllerIntTest {
-
-    @LocalServerPort
-    int port;
-
-    @Before
-    public void before() {
-        configureRestAssuredForIntTest(port);
-    }
+public class PingControllerIntTest extends BaseIntTest {
 
     @Test
     public void pingEndpoint() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/health/HealthCheckIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/health/HealthCheckIntTest.java
@@ -1,45 +1,18 @@
 package uk.gov.justice.probation.courtcaseservice.health;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.configureRestAssuredForIntTest;
 
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles(profiles = "test")
+@RunWith(SpringRunner.class)
 @DirtiesContext
-public class HealthCheckIntTest {
-
-    @LocalServerPort
-    int port;
-
-    @Before
-    public void before() {
-        configureRestAssuredForIntTest(port);
-    }
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
-
-    @Rule
-    public WireMockClassRule instanceRule = wireMockRule;
+public class HealthCheckIntTest extends BaseIntTest {
 
     @Test
     public void testUp() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/AssessmentsRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/AssessmentsRestClientIntTest.java
@@ -1,38 +1,26 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.OffenderNotFoundException;
 
 import java.time.LocalDateTime;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@ActiveProfiles("test")
-public class AssessmentsRestClientIntTest {
+public class AssessmentsRestClientIntTest extends BaseIntTest {
     private static final String CRN = "X320741";
     private static final String CRN_NOT_FOUND = "X320742";
     private static final String CRN_SERVER_ERROR = "CRNXXX";
 
     @Autowired
     private AssessmentsRestClient assessmentsRestClient;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void whenGetAssessmentByCrnCalled_thenMakeRestCallToAssessmentsApi() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
@@ -1,14 +1,11 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.controller.model.AttendanceResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CurrentOrderHeaderResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.ConvictionNotFoundException;
@@ -18,14 +15,10 @@ import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 import java.util.List;
 import java.util.Optional;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@ActiveProfiles("test")
-public class ConvictionRestClientIntTest {
+public class ConvictionRestClientIntTest extends BaseIntTest {
 
     public static final String CRN = "X320741";
     public static final Long SOME_CONVICTION_ID = 2500295343L;
@@ -36,11 +29,6 @@ public class ConvictionRestClientIntTest {
 
     @Autowired
     private ConvictionRestClient webTestClient;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void whenGetAttendancesByCrnAndConvictionIdToCommunityApi() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClientIntTest.java
@@ -1,17 +1,14 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.DocumentNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.OffenderNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
@@ -19,25 +16,17 @@ import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedD
 import java.io.IOException;
 import java.util.Optional;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
+
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@ActiveProfiles("test")
-public class DocumentRestClientIntTest {
+public class DocumentRestClientIntTest extends BaseIntTest {
 
     private static final String CRN = "X320741";
     private static final String SERVER_ERROR_CRN = "X320500";
 
     @Autowired
     private DocumentRestClient restClient;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void whenGetConvictionDocumentsCalled_thenMakeRestCallToCommunityApi() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/NsiRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/NsiRestClientIntTest.java
@@ -1,37 +1,25 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiNsi;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.NsiNotFoundException;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@ActiveProfiles("test")
-public class NsiRestClientIntTest {
+public class NsiRestClientIntTest extends BaseIntTest {
     private static final String CRN = "X320741";
     private static final long CONVICTION_ID = 2500295343L;
     public static final long NSI_ID = 2500003903L;
     @Autowired
     private NsiRestClient client;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void givenNsiExists_whenGetNsi_thenReturnIt() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/OffenderRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/OffenderRestClientIntTest.java
@@ -1,14 +1,11 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.ConvictionNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.OffenderNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.service.model.Requirement;
@@ -16,15 +13,11 @@ import uk.gov.justice.probation.courtcaseservice.service.model.Requirement;
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.probation.courtcaseservice.TestConfig.WIREMOCK_PORT;
 import static uk.gov.justice.probation.courtcaseservice.restclient.communityapi.mapper.OffenderMapperTest.EXPECTED_RQMNT_1;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@ActiveProfiles("test")
-public class OffenderRestClientIntTest {
+public class OffenderRestClientIntTest extends BaseIntTest {
 
     private static final String CRN = "X320741";
     private static final String CONVICTION_ID = "2500297061";
@@ -32,11 +25,6 @@ public class OffenderRestClientIntTest {
 
     @Autowired
     private OffenderRestClient offenderRestClient;
-
-    @ClassRule
-    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-            .port(WIREMOCK_PORT)
-            .usingFilesUnderClasspath("mocks"));
 
     @Test
     public void whenGetOffenderByCrnCalled_thenMakeRestCallToCommunityApi() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
@@ -1,26 +1,24 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 
-import java.time.LocalDateTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.SqlConfig;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
-
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
-@SpringBootTest
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-public class CourtCaseServiceIntTest {
+public class CourtCaseServiceIntTest extends BaseIntTest {
 
     private static final String COURT_CODE = "SHF";
     private static final String PRE_EXISTING_CASE_NO = "1600028913";


### PR DESCRIPTION
As a bit of background,  at startup, Spring Security now makes a request to the auth server for a public key to verify with. In our integration tests I've introduced a mock to make sure it doesn't fall over at this point - as we know though, wiremock can be a bit slow to start up and if the auth mocks aren't there then application will completely fail to start. 

The retry mechanism that we introduced was operating at the instance level in the @Before method, but because of the auth changes this is now too late - the first request will already have been made on application startup. To address this I've now moved that retry to @BeforeClass and made it static to allow this.

While I was in there I also extracted a BaseIntTest class which has removed a big chunk of boilerplate 🔥 