### PR TITLE
✨ Allow missing cases for a date to be deleted

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -97,7 +97,6 @@ public class CourtCaseController {
     @ApiOperation(value = "For the date / cases passed, delete any cases NOT in the list.")
     @ApiResponses(
         value = {
-            @ApiResponse(code = 204, message = "OK", response = CaseListResponse.class),
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
             @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
@@ -105,8 +104,8 @@ public class CourtCaseController {
             @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
         })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
-    @PutMapping(value = "/court/{courtCode}/cases/purge", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
-    public void deleteCasesByDate(@PathVariable String courtCode, @Valid @RequestBody Map<LocalDate, List<String>> existingCasesByDate) {
-        courtCaseService.deleteMissingCases(courtCode, existingCasesByDate);
+    @PutMapping(value = "/court/{courtCode}/cases/purgeAbsent", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public void purgeAbsentCases(@PathVariable String courtCode, @Valid @RequestBody Map<LocalDate, List<String>> existingCasesByDate) {
+        courtCaseService.deleteAbsentCases(courtCode, existingCasesByDate);
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -28,6 +26,8 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.CaseListRespon
 import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseResponse;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.service.CourtCaseService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Api(tags = "Court and Cases Resources")
 @RestController

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -1,9 +1,16 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -21,13 +28,6 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.CaseListRespon
 import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseResponse;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.service.CourtCaseService;
-
-import javax.validation.Valid;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Api(tags = "Court and Cases Resources")
 @RestController
@@ -92,5 +92,21 @@ public class CourtCaseController {
                 .map(courtCaseResponseMapper::mapFrom)
                 .collect(Collectors.toList());
         return CaseListResponse.builder().cases(courtCaseResponses).build();
+    }
+
+    @ApiOperation(value = "For the date / cases passed, delete any cases NOT in the list.")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 204, message = "OK", response = CaseListResponse.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "If the court is not found by the code passed."),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    @PutMapping(value = "/court/{courtCode}/cases/purge", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public void deleteCasesByDate(@PathVariable String courtCode, @Valid @RequestBody Map<LocalDate, List<String>> existingCasesByDate) {
+        courtCaseService.deleteMissingCases(courtCode, existingCasesByDate);
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
@@ -1,16 +1,27 @@
 package uk.gov.justice.probation.courtcaseservice.jpa.repository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Repository
-public interface CourtCaseRepository extends JpaRepository<CourtCaseEntity, Long> {
+public interface CourtCaseRepository extends CrudRepository<CourtCaseEntity, Long> {
     Optional<CourtCaseEntity> findByCourtCodeAndCaseNo(String courtCode, String caseNo);
 
     List<CourtCaseEntity> findByCourtCodeAndSessionStartTimeBetween(String courtCode, LocalDateTime start, LocalDateTime end);
+
+    @Query(value = "Select cc FROM CourtCaseEntity cc "
+        + "WHERE cc.courtCode = :courtCode "
+        + "AND cc.sessionStartTime >= :start AND cc.sessionStartTime <= :end "
+        + "AND cc.caseNo NOT IN :caseNos")
+    List<CourtCaseEntity> findCourtCasesNotIn(@Param("courtCode") String courtCode,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end,
+        @Param("caseNos") Collection<String> caseNos);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
-import static java.util.stream.Collectors.toMap;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -24,6 +22,8 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtRepository;
 import uk.gov.justice.probation.courtcaseservice.service.exceptions.EntityNotFoundException;
+
+import static java.util.stream.Collectors.toMap;
 
 @Service
 @Slf4j
@@ -79,7 +79,7 @@ public class CourtCaseService {
     }
 
     @Transactional
-    public void deleteMissingCases(String courtCode, Map<LocalDate, List<String>> existingCasesByDate) {
+    public void deleteAbsentCases(String courtCode, Map<LocalDate, List<String>> existingCasesByDate) {
         courtRepository.findByCourtCode(courtCode).orElseThrow(() -> new EntityNotFoundException("Court %s not found", courtCode));
 
         final Set<CourtCaseEntity> casesToDelete = new HashSet<>();

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
@@ -7,14 +7,17 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.InputMismatchException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
@@ -73,6 +76,26 @@ public class CourtCaseService {
 
     public void delete(String courtCode, String caseNo) {
         courtCaseRepository.deleteById(getCaseByCaseNumber(courtCode, caseNo).getId());
+    }
+
+    @Transactional
+    public void deleteMissingCases(String courtCode, Map<LocalDate, List<String>> existingCasesByDate) {
+        courtRepository.findByCourtCode(courtCode).orElseThrow(() -> new EntityNotFoundException("Court %s not found", courtCode));
+
+        final Set<CourtCaseEntity> casesToDelete = new HashSet<>();
+        existingCasesByDate.forEach((dateOfHearing, existingCaseNos) -> {
+            log.debug("Delete cases for court {} on date {}, not in list {}", courtCode, dateOfHearing, existingCaseNos);
+            LocalDateTime start = LocalDateTime.of(dateOfHearing, LocalTime.MIDNIGHT);
+            LocalDateTime end = start.plusDays(1);
+            casesToDelete.addAll(courtCaseRepository.findCourtCasesNotIn(courtCode, start, end, existingCaseNos));
+        });
+
+        if (log.isDebugEnabled()) {
+            casesToDelete.forEach(aCase -> log.debug("Soft delete case no {} for court {}, session time {} ",
+                aCase.getCaseNo(), aCase.getCourtCode(), aCase.getSessionStartTime()));
+        }
+
+        courtCaseRepository.deleteAll(casesToDelete);
     }
 
     private CourtCaseEntity processAndSave(CourtCaseEntity courtCaseEntity, Optional<CourtCaseEntity> existingCourtCaseEntity) {
@@ -155,5 +178,6 @@ public class CourtCaseService {
         IntStream.range(0, sortedOffences.size()).forEach(index -> sortedOffences.get(index).setSequenceNumber(index + 1));
         return sortedOffences;
     }
+
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -1,17 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import static io.restassured.RestAssured.given;
-import static java.time.Month.JANUARY;
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
-import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import java.nio.file.Files;
@@ -40,6 +28,18 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.BaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
+
+import static io.restassured.RestAssured.given;
+import static java.time.Month.JANUARY;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
+import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @RunWith(SpringRunner.class)
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -77,11 +77,6 @@ public class CourtCaseControllerPutIntTest extends BaseIntTest {
     private static final String JSON_CASE_NO = "1700028914";
     private static final String JSON_CASE_ID = "654321";
 
-//    @ClassRule
-//    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
-//            .port(WIREMOCK_PORT)
-//            .usingFilesUnderClasspath("mocks"));
-//
     @Before
     public void setup() throws Exception {
         caseDetailsJson = Files.readString(caseDetailsResource.getFile().toPath());
@@ -241,7 +236,7 @@ public class CourtCaseControllerPutIntTest extends BaseIntTest {
             .accept(ContentType.JSON)
             .body(Map.of(date1Jan, Arrays.asList("1000000", "1000001"), date2Jan, Arrays.asList("1000003", "1000007"), date3Jan, singletonList("1000010")))
             .when()
-            .put(String.format("/court/%s/cases/purge", COURT_CODE))
+            .put(String.format("/court/%s/cases/purgeAbsent", COURT_CODE))
             .then()
             .statusCode(HttpStatus.NO_CONTENT.value())
         ;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -1,27 +1,8 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.http.ContentType;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.SqlConfig;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
-import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
-import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
-import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
-
-import java.nio.file.Files;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
 import static io.restassured.RestAssured.given;
+import static java.time.Month.JANUARY;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -30,6 +11,35 @@ import static org.hamcrest.Matchers.not;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.BaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 
 @RunWith(SpringRunner.class)
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
@@ -67,6 +77,11 @@ public class CourtCaseControllerPutIntTest extends BaseIntTest {
     private static final String JSON_CASE_NO = "1700028914";
     private static final String JSON_CASE_ID = "654321";
 
+//    @ClassRule
+//    public static final WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig()
+//            .port(WIREMOCK_PORT)
+//            .usingFilesUnderClasspath("mocks"));
+//
     @Before
     public void setup() throws Exception {
         caseDetailsJson = Files.readString(caseDetailsResource.getFile().toPath());
@@ -210,6 +225,73 @@ public class CourtCaseControllerPutIntTest extends BaseIntTest {
             .body("message", equalTo("Case No 99999 and Court Code NWS do not match with values from body 1700028914 and SHF"))
         ;
 
+    }
+
+    @Test
+    public void whenPurgeCases_ThenReturn204NoContent() {
+
+        LocalDate date1Jan = LocalDate.of(2020, JANUARY, 1);
+        LocalDate date2Jan = LocalDate.of(2020, JANUARY, 2);
+        LocalDate date3Jan = LocalDate.of(2020, JANUARY, 3);
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(Map.of(date1Jan, Arrays.asList("1000000", "1000001"), date2Jan, Arrays.asList("1000003", "1000007"), date3Jan, singletonList("1000010")))
+            .when()
+            .put(String.format("/court/%s/cases/purge", COURT_CODE))
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+        ;
+
+        // 1 Jan - 2 cases - neither deleted
+        LocalDateTime start = LocalDateTime.of(date1Jan, LocalTime.MIDNIGHT);
+        List<CourtCaseEntity> courtCases1 = courtCaseRepository.findByCourtCodeAndSessionStartTimeBetween(COURT_CODE, start, start.plusDays(1));
+        assertThat(courtCases1).hasSize(2);
+        assertThat(courtCases1).extracting("deleted").containsOnly(Boolean.FALSE);
+
+        // 2 Jan - 6 cases - 4 removed and deleted also on child offences
+        start = LocalDateTime.of(date2Jan, LocalTime.MIDNIGHT);
+        List<CourtCaseEntity> courtCases2 = courtCaseRepository.findByCourtCodeAndSessionStartTimeBetween(COURT_CODE, start, start.plusDays(1));
+        assertThat(courtCases2).hasSize(6);
+        List<String> date2Deleted = courtCases2.stream()
+            .filter(BaseEntity::isDeleted)
+            .map(CourtCaseEntity::getCaseNo)
+            .collect(Collectors.toList());
+        assertThat(date2Deleted).containsAll(Arrays.asList("1000002", "1000005", "1000005", "1000006"));
+        List<OffenceEntity> deletedCaseWithOffences = courtCases2.stream()
+            .filter(e -> e.isDeleted() && !e.getOffences().isEmpty())
+            .findFirst()
+            .map(CourtCaseEntity::getOffences)
+            .orElseThrow();
+        assertThat(deletedCaseWithOffences).extracting("deleted").containsOnly(Boolean.TRUE);
+
+        // 3 Jan - all 2 removed
+        start = LocalDateTime.of(date3Jan, LocalTime.MIDNIGHT);
+        List<CourtCaseEntity> courtCases3 = courtCaseRepository.findByCourtCodeAndSessionStartTimeBetween(COURT_CODE, start, start.plusDays(1));
+        assertThat(courtCases3).hasSize(2);
+        assertThat(courtCases3).extracting("deleted").containsOnly(Boolean.TRUE);
+    }
+
+    @Test
+    public void givenUnknownCourtCode_whenPurgeCases_ThenReturn404() {
+
+        Map<LocalDate, List<Long>> existingCases = new HashMap<>(2);
+        existingCases.put(LocalDate.now(), Arrays.asList(1L, 4L));
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(existingCases)
+            .when()
+            .put(String.format("/court/%s/cases/purge", "XXX"))
+            .then()
+            .statusCode(HttpStatus.NOT_FOUND.value())
+        ;
     }
 
     private CourtCaseEntity createCaseDetails(String courtCode, String caseNo, String caseId) {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
@@ -1,9 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +15,10 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.CaseListRespon
 import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseResponse;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.service.CourtCaseService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CourtCaseControllerTest {
@@ -67,8 +67,8 @@ public class CourtCaseControllerTest {
 
         Map<LocalDate, List<String>> existingCases = Map.of(LocalDate.now(), Arrays.asList("1000003", "1000007"));
 
-        courtCaseController.deleteCasesByDate(COURT_CODE, existingCases);
+        courtCaseController.purgeAbsentCases(COURT_CODE, existingCases);
 
-        verify(courtCaseService).deleteMissingCases(COURT_CODE, existingCases);
+        verify(courtCaseService).deleteAbsentCases(COURT_CODE, existingCases);
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ConvictionServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ConvictionServiceTest.java
@@ -1,11 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +18,12 @@ import uk.gov.justice.probation.courtcaseservice.restclient.exception.OffenderNo
 import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 import uk.gov.justice.probation.courtcaseservice.service.model.Sentence;
 import uk.gov.justice.probation.courtcaseservice.service.model.UnpaidWork;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ConvictionServiceTest {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
@@ -65,7 +65,7 @@ public class CourtCaseServiceIntTest extends BaseIntTest {
         List<String> existingCases = Arrays.asList("1000003", "1000007");
         final Map<LocalDate, List<String>> existing = Map.of(date2Jan, existingCases);
 
-        courtCaseService.deleteMissingCases(COURT_CODE, existing);
+        courtCaseService.deleteAbsentCases(COURT_CODE, existing);
 
         List<String> expectedDeletions = Arrays.asList("1000002", "1000004", "1000005", "1000006");
         expectedDeletions.forEach(caseNo -> {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceIntTest.java
@@ -1,9 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
-import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -18,6 +14,10 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 
 @RunWith(SpringRunner.class)
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceTest.java
@@ -1,22 +1,29 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
+import java.util.Arrays;
 import java.util.InputMismatchException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.util.StringUtils;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
@@ -67,12 +74,11 @@ class CourtCaseServiceTest {
 
     private CourtCaseEntity courtCase;
 
+    @InjectMocks
     private CourtCaseService service;
 
     @BeforeEach
     void setup() {
-        service = new CourtCaseService(courtRepository, courtCaseRepository);
-
         courtCase = buildCourtCase();
     }
 
@@ -149,6 +155,35 @@ class CourtCaseServiceTest {
         assertThatExceptionOfType(InputMismatchException.class).isThrownBy( () ->
             service.createOrUpdateCase(COURT_CODE, misMatchCaseNo, courtCase)
         ).withMessage("Case No " + misMatchCaseNo + " and Court Code " + COURT_CODE + " do not match with values from body " + CASE_NO + " and " + COURT_CODE);
+    }
+
+    @Test
+    void whenDeleteMissingCases_ThenCallRepo() {
+
+        LocalDateTime start = LocalDateTime.of(2020, Month.JANUARY, 1, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2020, Month.JANUARY, 2, 0, 0);
+        List<String> caseNos = Arrays.asList("100", "101");
+        final Map<LocalDate, List<String>> existingCases = Map.of(start.toLocalDate(), Arrays.asList("100", "101"));
+        when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
+        CourtCaseEntity caseToDelete = mock(CourtCaseEntity.class);
+        when(courtCaseRepository.findCourtCasesNotIn(COURT_CODE, start, end, caseNos)).thenReturn(singletonList(caseToDelete));
+
+        service.deleteMissingCases(COURT_CODE, existingCases);
+
+        verify(courtCaseRepository).deleteAll(Set.of(caseToDelete));
+    }
+
+    @Test
+    void givenUnknownCourt_whenDeleteMissingCases_ThenThrow() {
+
+        when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.empty());
+        LocalDateTime start = LocalDateTime.of(2020, Month.JANUARY, 1, 0, 0);
+        final Map<LocalDate, List<String>> existingCases = Map.of(start.toLocalDate(), Arrays.asList("100", "101"));
+
+        var exception = catchThrowable(() ->
+            service.deleteMissingCases(COURT_CODE, existingCases));
+        assertThat(exception).isInstanceOf(EntityNotFoundException.class)
+            .hasMessageContaining("Court " + COURT_CODE + " not found");
     }
 
     static CourtCaseEntity buildCourtCase() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseServiceTest.java
@@ -1,14 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -33,6 +24,15 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtRepository;
 import uk.gov.justice.probation.courtcaseservice.service.exceptions.EntityNotFoundException;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CourtCaseServiceTest {
@@ -168,7 +168,7 @@ class CourtCaseServiceTest {
         CourtCaseEntity caseToDelete = mock(CourtCaseEntity.class);
         when(courtCaseRepository.findCourtCasesNotIn(COURT_CODE, start, end, caseNos)).thenReturn(singletonList(caseToDelete));
 
-        service.deleteMissingCases(COURT_CODE, existingCases);
+        service.deleteAbsentCases(COURT_CODE, existingCases);
 
         verify(courtCaseRepository).deleteAll(Set.of(caseToDelete));
     }
@@ -181,7 +181,7 @@ class CourtCaseServiceTest {
         final Map<LocalDate, List<String>> existingCases = Map.of(start.toLocalDate(), Arrays.asList("100", "101"));
 
         var exception = catchThrowable(() ->
-            service.deleteMissingCases(COURT_CODE, existingCases));
+            service.deleteAbsentCases(COURT_CODE, existingCases));
         assertThat(exception).isInstanceOf(EntityNotFoundException.class)
             .hasMessageContaining("Court " + COURT_CODE + " not found");
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,3 +19,8 @@ nomis-oauth:
 spring:
   flyway:
     clean-on-validation-error: true
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: false

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -46,4 +46,34 @@ INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court
 '2019-12-14 23:59:59', 'No record', 'X320741');
 
 
+-- See CourtCaseControllerPutIntTest.whenPurgeCases_ThenReturn204NoContent()
+-- These records are used to test edge cases when returning court case list for a given date (midnight to 1 second before midnight the next day)
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000000, 1000000, 1000000, 'SHF', 1, '2020-01-01 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000001, 1000001, 1000001, 'SHF', 1, '2020-01-01 09:00:00', 'No record', 'X320741');
+
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000002, 1000002, 1000002, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000003, 1000003, 1000003, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000004, 1000004, 1000004, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000005, 1000005, 1000005, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000006, 1000006, 1000006, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000007, 1000007, 1000007, 'SHF', 1, '2020-01-02 09:00:00', 'No record', 'X320741');
+
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000008, 1000008, 1000008, 'SHF', 1, '2020-01-03 09:00:00', 'No record', 'X320741');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
+VALUES (1000009, 1000009, 1000009, 'SHF', 1, '2020-01-03 09:00:00', 'No record', 'X320741');
+
+INSERT INTO courtcaseservicetest.OFFENCE (ID, CASE_NO, COURT_CODE, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER	)
+VALUES (1000001, 1000001, 'SHF', 'Title', 'Summary.', 'ACT.', 1);
+INSERT INTO courtcaseservicetest.OFFENCE (ID, CASE_NO, COURT_CODE, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER	)
+VALUES (1000002, 1000002, 'SHF', 'Title', 'Summary.', 'ACT.', 2);
+
 

--- a/src/test/resources/http-request/court-case-ctrl.rest
+++ b/src/test/resources/http-request/court-case-ctrl.rest
@@ -98,4 +98,26 @@ GET http://{{host}}/court/SHF/cases?date=1903-01-13
 Accept: application/json
 
 ###
+# Update a case by court and code
+PUT http://{{host}}/court/{{courtCode}}/cases/purge
+Content-Type: application/json
 
+{
+    "2020-01-01": [
+        "1000000",
+        "1000001"
+    ],
+    "2020-01-02": [
+        "1000003",
+        "1000007"
+    ],
+    "2020-01-03": [
+        "1000010"
+    ]
+}
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 204, "Response status is not 204");
+    });
+%}


### PR DESCRIPTION
The code takes a list of case numbers for a date / court code and deletes any cases found for that court / date which are not n the list of case numbers. The list of case numbers has arrived and is the full list of cases for that date / court.

The approach is to use SQL to get a list of cases to delete and then use a standard Spring-provided repository delete method to delete them. Due to work done earlier, this is a "soft delete" and cascades to child offences. Other approaches were looked at 

- Custom query to to a DELETE. Unfortunately it's a feature of JPA that this doesn't cascade to child entities and doesn't understand the soft delete. SO we'd have had to write it as an UPDATE on both the COURT_CASE and OFFENCE tables.
- CriteriaBuilder - again this would have to be written as an UPDATE. I trialled this approach and whilst it works, it results in having to manage transactions with the EntityManager and very many more lines of code.  The CriteriaBuilder tools are useful for other scenarios and might be better if we were looking at large batch deletes, at least dozens of records. We are probably looking at a maximum of one or two deletes per transaction and in many cases, zero.

