### PR TITLE
🐛 Refine sort order for convictions

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderService.java
@@ -1,9 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -21,6 +19,7 @@ import uk.gov.justice.probation.courtcaseservice.restclient.OffenderRestClient;
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.OffenderNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.service.model.Assessment;
 import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
+import uk.gov.justice.probation.courtcaseservice.service.model.ConvictionBySentenceComparator;
 import uk.gov.justice.probation.courtcaseservice.service.model.LicenceCondition;
 import uk.gov.justice.probation.courtcaseservice.service.model.OffenderDetail;
 import uk.gov.justice.probation.courtcaseservice.service.model.ProbationRecord;
@@ -75,11 +74,8 @@ public class OffenderService {
                         return conviction;
                     });
             })
-            .collectSortedList(Comparator.comparing(conviction ->
-                    Optional.ofNullable(conviction.getSentence())
-                        .map(c -> conviction.getSentence().getTerminationDate())
-                        .orElse(null),
-                Comparator.nullsFirst(Comparator.reverseOrder())));
+            .collectSortedList(new ConvictionBySentenceComparator()
+                                .thenComparing(Conviction::getConvictionId));
 
         // This Mono resolves to a 3 tuple containing the record itself, the above-mentioned convictions, and the documents
         Mono<Tuple3<ProbationRecord, List<Conviction>, GroupedDocuments>> probationMono = Mono.zip(

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/Conviction.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/Conviction.java
@@ -1,9 +1,11 @@
 package uk.gov.justice.probation.courtcaseservice.service.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,5 +36,15 @@ public class Conviction implements Comparable<Conviction>{
     @Override
     public int compareTo(Conviction other) {
         return ((Long)Long.parseLong(convictionId)).compareTo(Long.parseLong(other.getConvictionId()));
+    }
+
+    @JsonIgnore
+    public Optional<LocalDate> getSentenceStartDate() {
+        return Optional.ofNullable(sentence).map(Sentence::getStartDate);
+    }
+
+    @JsonIgnore
+    public Optional<LocalDate> getSentenceTerminationDate() {
+        return Optional.ofNullable(sentence).map(Sentence::getTerminationDate);
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionBySentenceComparator.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionBySentenceComparator.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.probation.courtcaseservice.service.model;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Compare convictions by their sentences. Priority described in English.
+ *
+ * <ol>
+ *     <li>Active - to appear first. For active orders, sort so that most recent by sentence start date appear at the top of the list. Nulls last.</li>
+ *     <li>Non-active - to appear after active. For non-active orders, sort so that most recent by termination date appear at the top of the list. Nulls last.</li>
+ * </ol>
+ *
+ */
+public class ConvictionBySentenceComparator implements Comparator<Conviction> {
+
+    @Override
+    public int compare(Conviction conviction, Conviction convictionOther) {
+        if (Objects.equals(conviction.getActive(), convictionOther.getActive())) {
+            if (Optional.ofNullable(conviction.getActive()).orElse(Boolean.FALSE)) {
+                return convictionOther.getSentenceStartDate().orElse(LocalDate.MIN)
+                    .compareTo(conviction.getSentenceStartDate().orElse(LocalDate.MIN));
+            }
+            else {
+                return convictionOther.getSentenceTerminationDate().orElse(LocalDate.MIN)
+                    .compareTo(conviction.getSentenceTerminationDate().orElse(LocalDate.MIN));
+            }
+        }
+        else {
+            return Optional.ofNullable(conviction.getActive())
+                .map(active -> active ? -1 : 1)
+                .orElse(-1);
+        }
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -61,14 +61,24 @@ public class OffenderControllerIntTest extends BaseIntTest {
                 .body("offenderManagers[0].surname", equalTo("Brennan"))
                 .body("offenderManagers[0].allocatedDate", equalTo(standardDateOf(2019, 9, 30)))
 
-                .body("convictions[0].convictionId", equalTo("2500295343"))
-                .body("convictions[0].active", equalTo(null))
-                .body("convictions[0].inBreach", equalTo(true))
+                .body("convictions[0].convictionId", equalTo("2500295345"))
+                .body("convictions[0].active", equalTo(true))
+                .body("convictions[0].inBreach", equalTo(false))
                 .body("convictions[0].offences[0].description", equalTo("Arson - 05600"))
-                .body("convictions[0].convictionDate", equalTo(null))
-                .body("convictions[0].documents", hasSize(0))
-                .body("convictions[0].breaches", hasSize(1))
-                .body("convictions[0].breaches[0].breachId", equalTo(11131321))
+                .body("convictions[0].offences[1].description", equalTo("Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"))
+                .body("convictions[0].sentence.sentenceId", equalTo("123457"))
+                .body("convictions[0].sentence.description", equalTo("CJA - Indeterminate Public Prot."))
+                .body("convictions[0].sentence.length", equalTo(5))
+                .body("convictions[0].sentence.lengthUnits", equalTo("Years"))
+                .body("convictions[0].sentence.lengthInDays", equalTo(1826))
+                .body("convictions[0].sentence.terminationDate", equalTo(standardDateOf(2019, 1, 1)))
+                .body("convictions[0].sentence.terminationReason", equalTo("ICMS Miscellaneous Event"))
+                .body("convictions[0].convictionDate", equalTo(standardDateOf(2019, 9,3)))
+                .body("convictions[0].documents", hasSize(1))
+                .body("convictions[0].documents[0].documentId", equalTo("1d842fce-ec2d-45dc-ac9a-748d3076ca6b"))
+                .body("convictions[0].breaches", hasSize(0))
+                .body("convictions[0].endDate", equalTo(standardDateOf(2019, 1,1)))
+                .body("convictions[0].sentence.endDate", equalTo(standardDateOf(2019, 1,1)))
 
                 .body("convictions[1].convictionId", equalTo("2500297061"))
                 .body("convictions[1].active", equalTo(false))
@@ -87,27 +97,14 @@ public class OffenderControllerIntTest extends BaseIntTest {
                 .body("convictions[1].breaches", hasSize(1))
                 .body("convictions[1].breaches[0].breachId", equalTo(11131321))
 
-                .body("convictions[2].convictionId", equalTo("2500295345"))
-                .body("convictions[2].active", equalTo(true))
-                .body("convictions[2].inBreach", equalTo(false))
+                .body("convictions[2].convictionId", equalTo("2500295343"))
+                .body("convictions[2].active", equalTo(false))
+                .body("convictions[2].inBreach", equalTo(true))
                 .body("convictions[2].offences[0].description", equalTo("Arson - 05600"))
-                .body("convictions[2].offences[1].description", equalTo("Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"))
-                .body("convictions[2].sentence.sentenceId", equalTo("123457"))
-                .body("convictions[2].sentence.description", equalTo("CJA - Indeterminate Public Prot."))
-                .body("convictions[2].sentence.length", equalTo(5))
-                .body("convictions[2].sentence.lengthUnits", equalTo("Years"))
-                .body("convictions[2].sentence.lengthInDays", equalTo(1826))
-                .body("convictions[2].sentence.terminationDate", equalTo(standardDateOf(2019, 1, 1)))
-                .body("convictions[2].sentence.terminationReason", equalTo("ICMS Miscellaneous Event"))
-                .body("convictions[2].convictionDate", equalTo(standardDateOf(2019, 9,3)))
-                .body("convictions[2].documents", hasSize(1))
-                .body("convictions[2].documents[0].documentId", equalTo("1d842fce-ec2d-45dc-ac9a-748d3076ca6b"))
-                .body("convictions[2].breaches", hasSize(0))
-                .body("convictions[2].endDate", equalTo(standardDateOf(2019, 1,1)))
-                .body("convictions[2].sentence.endDate", equalTo(standardDateOf(2019, 1,1)))
-
-
-
+                .body("convictions[2].convictionDate", equalTo(null))
+                .body("convictions[2].documents", hasSize(0))
+                .body("convictions[2].breaches", hasSize(1))
+                .body("convictions[2].breaches[0].breachId", equalTo(11131321))
         ;
     }
 
@@ -123,14 +120,15 @@ public class OffenderControllerIntTest extends BaseIntTest {
                 .statusCode(200)
                 .body("crn",  equalTo("X320741"))
                 .body("convictions.size()", is(3))
-                .body("convictions[0].convictionId", equalTo("2500295343"))
-                .body("convictions[0].documents", hasSize(7))
+
+                .body("convictions[0].convictionId", equalTo("2500295345"))
+                .body("convictions[0].documents", hasSize(8))
 
                 .body("convictions[1].convictionId", equalTo("2500297061"))
                 .body("convictions[1].documents", hasSize(0))
 
-                .body("convictions[2].convictionId", equalTo("2500295345"))
-                .body("convictions[2].documents", hasSize(8))
+                .body("convictions[2].convictionId", equalTo("2500295343"))
+                .body("convictions[2].documents", hasSize(7))
         ;
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionBySentenceComparatorTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionBySentenceComparatorTest.java
@@ -1,0 +1,125 @@
+package uk.gov.justice.probation.courtcaseservice.service.model;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConvictionBySentenceComparatorTest {
+
+    private static final LocalDate EARLIEST = LocalDate.of(2019, Month.JULY, 29);
+    private static final LocalDate MIDDLE = LocalDate.of(2019, Month.JULY, 30);
+    private static final LocalDate LATEST = LocalDate.of(2019, Month.JULY, 31);
+
+    private static ConvictionBySentenceComparator comparator;
+
+    @BeforeAll
+    static void beforeAll() {
+        comparator = new ConvictionBySentenceComparator();
+    }
+
+    @DisplayName("Comparing active convictions, use sentence start date")
+    @Test
+    void givenAllActive_whenSort_thenMostRecentStartDateFirst() {
+        Conviction conviction1 = buildConviction("1", LATEST, null, Boolean.TRUE);
+        Conviction conviction2 = buildConviction("2", EARLIEST, null, Boolean.TRUE);
+
+        List<Conviction> convictions = Stream.of(conviction2, conviction1)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2);
+    }
+
+    @DisplayName("Comparing active convictions, use sentence start date with null date at end")
+    @Test
+    void givenAllActiveWithNullDate_whenSort_thenMostRecentStartDateFirst() {
+        Conviction conviction1 = buildConviction("1", EARLIEST, null, Boolean.TRUE);
+        Conviction conviction2 = buildConviction("2", null, null, Boolean.TRUE);
+
+        List<Conviction> convictions = Stream.of(conviction2, conviction1)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2);
+    }
+
+    @DisplayName("Comparing non-active convictions, use sentence termination date with most recent first")
+    @Test
+    void givenAllNonActive_whenSort_thenMostRecentTerminationDateFirst() {
+
+        Conviction conviction1 = buildConviction("1", EARLIEST, LATEST, Boolean.FALSE);
+        Conviction conviction2 = buildConviction("2", LATEST, MIDDLE, Boolean.FALSE);
+        Conviction conviction3 = buildConviction("3", LATEST, EARLIEST, Boolean.FALSE);
+
+        List<Conviction> convictions = Stream.of(conviction2, conviction1, conviction3)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2, conviction3);
+    }
+
+    @DisplayName("Comparing active convictions, use sentence start date with null date at end")
+    @Test
+    void givenNullSentenceInActive_whenSort_thenReturnSentenceFirst() {
+
+        Conviction conviction1 = buildConviction("2", EARLIEST, LATEST, Boolean.TRUE);
+        Conviction conviction2 = Conviction.builder().convictionId("1").active(Boolean.TRUE).build();
+        Conviction conviction3 = buildConviction("3", EARLIEST, LATEST, Boolean.FALSE);
+
+        List<Conviction> convictions = Stream.of(conviction2, conviction1, conviction3)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2, conviction3);
+    }
+
+    @DisplayName("Comparing mix of active convictions")
+    @Test
+    void givenOneNullActive_whenSort_thenActiveFirstTreatNullAsNonActive() {
+        // 1 first because active, despite old dates. 2 considered non-active and next because most recent
+        Conviction conviction1 = buildConviction("1", EARLIEST, EARLIEST, Boolean.TRUE);
+        Conviction conviction2 = buildConviction("2", LATEST, LATEST, null);
+        Conviction conviction3 = buildConviction("3", LATEST, EARLIEST, Boolean.FALSE);
+
+        List<Conviction> convictions = Stream.of(conviction3, conviction2, conviction1)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2, conviction3);
+    }
+
+    @DisplayName("Comparing mix of active convictions")
+    @Test
+    void givenAllNullActive_whenSort_thenSortByTerminationDate() {
+        //All non-active null, sort by
+        Conviction conviction1 = buildConviction("1", EARLIEST, LATEST, null);
+        Conviction conviction2 = buildConviction("2", LATEST, EARLIEST, null);
+        Conviction conviction3 = buildConviction("3", LATEST, null, null);
+
+        List<Conviction> convictions = Stream.of(conviction3, conviction2, conviction1)
+            .sorted(comparator)
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction1, conviction2, conviction3);
+    }
+
+    private Conviction buildConviction(String convictionId, LocalDate sentenceStartDate, LocalDate sentenceTerminationDate, Boolean active) {
+        return Conviction.builder()
+            .active(active)
+            .convictionId(convictionId)
+            .sentence(Sentence.builder()
+                .startDate(sentenceStartDate)
+                .terminationDate(sentenceTerminationDate)
+                .build())
+            .build();
+    }
+
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/model/ConvictionTest.java
@@ -1,0 +1,83 @@
+package uk.gov.justice.probation.courtcaseservice.service.model;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConvictionTest {
+
+    @DisplayName("Get start date with no nulls")
+    @Test
+    void whenGetStartDate_thenReturn() {
+        Conviction conviction = Conviction.builder()
+                    .sentence(Sentence.builder()
+                        .startDate(LocalDate.now())
+                        .build())
+            .build();
+
+        assertThat(conviction.getSentenceStartDate()).isPresent();
+    }
+
+    @DisplayName("Start date with no sentence, should return empty optional")
+    @Test
+    void givenNullSentence_whenGetStartDate_thenReturnEmpty() {
+        assertThat(Conviction.builder().build().getSentenceStartDate()).isNotPresent();
+    }
+
+    @DisplayName("Start date with a sentence but no start date, should return empty optional")
+    @Test
+    void givenSentenceWithNullStartDate_whenGetStartDate_thenReturnEmpty() {
+        Conviction conviction = Conviction.builder()
+            .sentence(Sentence.builder().build())
+            .build();
+
+        assertThat(conviction.getSentenceStartDate()).isNotPresent();
+    }
+
+    @DisplayName("Get termination date with no nulls")
+    @Test
+    void whenGetTerminationDate_thenReturn() {
+        Conviction conviction = Conviction.builder()
+            .sentence(Sentence.builder()
+                .terminationDate(LocalDate.now())
+                .build())
+            .build();
+
+        assertThat(conviction.getSentenceTerminationDate()).isPresent();
+    }
+
+    @DisplayName("Termination date with no sentence, should return empty optional")
+    @Test
+    void givenNullSentence_whenGetTerminationDate_thenReturnEmpty() {
+        assertThat(Conviction.builder().build().getSentenceTerminationDate()).isNotPresent();
+    }
+
+    @DisplayName("Start date with a sentence but no termination date, should return empty optional")
+    @Test
+    void givenSentenceWithNullTerminationDate_whenGetStartDate_thenReturnEmpty() {
+        Conviction conviction = Conviction.builder()
+            .sentence(Sentence.builder().build())
+            .build();
+
+        assertThat(conviction.getSentenceTerminationDate()).isNotPresent();
+    }
+
+    @DisplayName("Invoke the Conviction object's compareTo implementation to sort by ID ascending")
+    @Test
+    void whenSort_ThenReturnByIdAsc() {
+        Conviction conviction1 = Conviction.builder().convictionId("123450").build();
+        Conviction conviction2 = Conviction.builder().convictionId("99999").build();
+        Conviction conviction3 = Conviction.builder().convictionId("12345").build();
+
+        List<Conviction> convictions = Stream.of(conviction2, conviction3, conviction1)
+            .sorted()
+            .collect(Collectors.toList());
+
+        assertThat(convictions).containsExactly(conviction3, conviction2, conviction1);
+    }
+}

--- a/src/test/resources/mocks/__files/offender-convictions/GET_offender_convictions_X320741.json
+++ b/src/test/resources/mocks/__files/offender-convictions/GET_offender_convictions_X320741.json
@@ -141,6 +141,7 @@
     "convictionId": 2500295343,
     "index": "1",
     "inBreach": true,
+    "active": false,
     "referralDate": "2017-06-01",
     "offences": [
       {


### PR DESCRIPTION
The existing sort order needs to handle active and non-active differently