### PR TITLE
👷‍♂️ PIC-826: Enable CircleCI Jira integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ commands:
               --values ~/git/helm_deploy/values-<< parameters.env >>.yaml \
               --values - \
               --set image.tag="${APP_VERSION}"
+      - jira/notify:
+          environment: << parameters.env >>
+          job_type: deployment
 executors:
   deployer:
     docker:
@@ -94,6 +97,7 @@ orbs:
   helm: circleci/helm@0.1.2
   mem: circleci/rememborb@0.0.1
   snyk: snyk/snyk@0.0.12
+  jira: circleci/jira@1.2.2
 
 _snyk_options: &snyk_options
   organization: "digital-probation-services"
@@ -125,6 +129,9 @@ jobs:
           paths:
             - build/libs
             - build.gradle
+      - jira/notify:
+          token_name: JIRA_CIRCLE_TOKEN
+          job_type: build
 
   build_docker:
     executor: deployer
@@ -168,6 +175,9 @@ jobs:
                   docker tag mojdigitalstudio/court-case-service:$APP_VERSION mojdigitalstudio/court-case-service:latest
                   docker push mojdigitalstudio/court-case-service:$APP_VERSION
                   docker push mojdigitalstudio/court-case-service:latest
+      - jira/notify:
+          token_name: JIRA_CIRCLE_TOKEN
+          job_type: build
 
   app_scan:
     executor: builder


### PR DESCRIPTION
See [ticket](https://dsdmoj.atlassian.net/browse/PIC-826) for proof it's working.

Note that it isn't clever enough to distinguish between different jobs in a build - as far as Jira is concerned it's either built or it isn't. Because of this I'm reporting only on build and docker-build which are sequential so we won't get a situation where a parallel job succeeds and overrides a previously reported and valid failure status. If the app scan fails we won't see it in Jira but this seems to just be a limitation of the integration.