### PR TITLE
👌🏻 PIC-442 Fix path for court appearances within the breach endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/OffenderDetail.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/OffenderDetail.java
@@ -2,6 +2,7 @@ package uk.gov.justice.probation.courtcaseservice.service.model;
 
 import java.time.LocalDate;
 import java.util.List;
+import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.justice.probation.courtcaseservice.controller.model.ProbationStatus;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.OtherIds;
 
+@ApiModel("The Offender detail")
 @Data
 @Builder
 @AllArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ community-api:
   nsis-url-template: /secure/offenders/crn/%s/convictions/%s/nsis
   current-order-header-url-template: /secure/offenders/crn/%s/convictions/%s/sentences/%s/custodialStatus
   nsi-by-id-url-template: /secure/offenders/crn/%s/convictions/%s/nsis/%s
-  court-appearances-by-crn-and-nsi-url-template: /offenders/crn/%s/convictions/%s/courtAppearances
+  court-appearances-by-crn-and-nsi-url-template: /secure/offenders/crn/%s/convictions/%s/courtAppearances
 
   probation-record-filter.document.types: "COURT_REPORT_DOCUMENT"
   probation-record-filter.document.subtype.codes: "CJF,CJO,CJS,PSA,PSB,PSN,PSR,SSR,XPR,CR02,CR05"

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -134,56 +133,6 @@ public class OffenderControllerIntTest extends BaseIntTest {
 
                 .body("convictions[2].convictionId", equalTo("2500295343"))
                 .body("convictions[2].documents", hasSize(7))
-        ;
-    }
-
-    @Test
-    public void whenCallMadeToGetBreach_thenReturnCorrectData() {
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-                .get("/offender/X320741/convictions/2500295343/breaches/2500003903")
-        .then()
-                .statusCode(200)
-                .body("breachId", equalTo(2500003903L))
-                .body("incidentDate", equalTo("2017-03-21"))
-                .body("started", equalTo("2017-03-22"))
-                .body("provider", equalTo("CPA West Yorkshire"))
-                .body("team", equalTo("Unallocated"))
-                .body("officer", equalTo("Unallocated Staff"))
-                .body("status", equalTo("Induction Completed - Opted Out"))
-                .body("order", equalTo("CJA - Community Order (12 Months)"))
-                .body("sentencingCourtName", equalTo("Bicester Magistrates Court"))
-                .body("documents", hasSize(1))
-        ;
-    }
-
-    @Test
-    public void whenBreachDoesNotExist_thenReturn404() {
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-            .get("/offender/D003080/convictions/2500295343/breaches/1230000000")
-        .then()
-            .statusCode(404)
-        ;
-    }
-
-    @Ignore("This test is non-deterministic because there are three calls made but only one has been mocked to return a 500. Defect: PIC-507")
-    @Test
-    public void whenBreachThrowsServerError_thenReturn500() {
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-            .get("/offender/X320123/convictions/2500295343/breaches/2500003903")
-        .then()
-            .statusCode(500)
         ;
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_BreachIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderController_BreachIntTest.java
@@ -1,0 +1,103 @@
+package uk.gov.justice.probation.courtcaseservice.controller;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "org.apache.catalina.connector.RECYCLE_FACADES=true")
+public class OffenderController_BreachIntTest extends BaseIntTest {
+
+    private static final String CRN = "X320741";
+    private static final String CONVICTION_ID = "2500295343";
+    private static final String BREACH_ID = "2500003903";
+    private static final String UNKNOWN_CRN = "CRNXXX";
+
+    private static final String GET_BREACH_PATH = "/offender/%s/convictions/%s/breaches/%s";
+
+    @Test
+    public void whenCallMadeToGetBreach_thenReturnCorrectData() {
+
+        String path = String.format(GET_BREACH_PATH, CRN, CONVICTION_ID, BREACH_ID);
+        given()
+            .auth()
+            .oauth2(getToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+                .get(path)
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("breachId", equalTo(2500003903L))
+                .body("incidentDate", equalTo("2017-03-21"))
+                .body("started", equalTo("2017-03-22"))
+                .body("provider", equalTo("CPA West Yorkshire"))
+                .body("team", equalTo("Unallocated"))
+                .body("officer", equalTo("Unallocated Staff"))
+                .body("status", equalTo("Induction Completed - Opted Out"))
+                .body("order", equalTo("CJA - Community Order (12 Months)"))
+                .body("sentencingCourtName", equalTo("Bicester Magistrates Court"))
+                .body("documents", hasSize(1))
+        ;
+    }
+
+    @Test
+    public void givenUnknownBreachId_whenGetBreach_thenReturn404() {
+        // Three of the four API calls return 200 status code but the breach ID is unknown
+        String path = String.format(GET_BREACH_PATH, CRN, CONVICTION_ID, "0");
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get(path)
+            .then()
+            .statusCode(404)
+            .body("developerMessage", equalTo("Nsi with id '0' not found for convictionId '2500295343' and crn 'X320741'"))
+        ;
+    }
+
+    @Test
+    public void givenUnknownCrn_whenGetBreach_thenReturn404() {
+
+        String path = String.format(GET_BREACH_PATH, UNKNOWN_CRN, CONVICTION_ID, BREACH_ID);
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(404)
+        ;
+    }
+
+    @Test
+    public void whenBreachThrowsServerError_thenReturn500() {
+        // Three of the four calls here will return data with 200 status code
+        // but the NSI one gives a 500 status code
+        String path = String.format(GET_BREACH_PATH, CRN, CONVICTION_ID, "500");
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(500)
+        ;
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.restclient;
 
+import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +13,6 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.CurrentOrderHe
 import uk.gov.justice.probation.courtcaseservice.restclient.exception.ConvictionNotFoundException;
 import uk.gov.justice.probation.courtcaseservice.service.model.Conviction;
 
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -24,7 +23,7 @@ public class ConvictionRestClientIntTest extends BaseIntTest {
     public static final Long SOME_SENTENCE_ID = 2500298861L;
     public static final Long UNKNOWN_CONVICTION_ID = 9999L;
     public static final String SERVER_ERROR_CRN = "X320500";
-    public static final String UNKNOWN_CRN = "X320999";
+    public static final String UNKNOWN_CRN = "CRNXXX";
 
     @Autowired
     private ConvictionRestClient webTestClient;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/NsiRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/NsiRestClientIntTest.java
@@ -30,7 +30,7 @@ public class NsiRestClientIntTest extends BaseIntTest {
     }
 
     @Test
-    public void givenNsiDoesNotExist_whenGetNsi_thenReturnEmpty() {
+    public void givenNsiDoesNotExist_whenGetNsi_thenReturnThrowNotFound() {
         assertThatExceptionOfType(NsiNotFoundException.class)
             .isThrownBy(() -> client.getNsiById(CRN, CONVICTION_ID, 1230045000L).block())
             .withMessage("Nsi with id '1230045000' not found for convictionId '2500295343' and crn 'X320741'");
@@ -39,7 +39,6 @@ public class NsiRestClientIntTest extends BaseIntTest {
     @Test
     public void givenServerError_whenGetNsi_thenThrow() {
         assertThatExceptionOfType(WebClientResponseException.class)
-                .isThrownBy(() -> client.getNsiById("X320123", CONVICTION_ID, NSI_ID).block());
-
+                .isThrownBy(() -> client.getNsiById(CRN, CONVICTION_ID, 500L).block());
     }
 }

--- a/src/test/resources/mocks/mappings/attendances/GET_offender_attendances_server_404_X320999.json
+++ b/src/test/resources/mocks/mappings/attendances/GET_offender_attendances_server_404_X320999.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/secure/offenders/crn/X320999/convictions/2500295343/attendancesFilter",
+    "urlPath": "/secure/offenders/crn/CRNXXX/convictions/2500295343/attendancesFilter",
     "headers" : {
       "Content-Type": {
         "equalTo": "application/json"
@@ -13,6 +13,6 @@
     "headers": {
       "Content-Type": "application/json"
     },
-    "body": "{\"developerMessage\": \"Offender ID not found for CRN X320742\"}"
+    "body": "{\"developerMessage\": \"Offender ID not found for CRN CRNXXX\"}"
   }
 }

--- a/src/test/resources/mocks/mappings/offender-appearances/GET_appearances_success_X320741.json
+++ b/src/test/resources/mocks/mappings/offender-appearances/GET_appearances_success_X320741.json
@@ -1,7 +1,7 @@
 {
     "request": {
       "method": "GET",
-      "urlPath": "/offenders/crn/X320741/convictions/2500295343/courtAppearances",
+      "urlPath": "/secure/offenders/crn/X320741/convictions/2500295343/courtAppearances",
       "headers" : {
         "Content-Type": {
           "equalTo": "application/json"

--- a/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_404_CRNXXX.json
+++ b/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_404_CRNXXX.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/secure/offenders/crn/X320123/convictions/2500295343/nsis/2500003903",
+    "urlPath": "/secure/offenders/crn/CRNXXX/convictions/2500295343/nsis/2500003903",
     "headers" : {
       "Content-Type": {
         "equalTo": "application/json"
@@ -9,9 +9,10 @@
     }
   },
   "response": {
-    "status": 500,
+    "status": 404,
     "headers": {
       "Content-Type": "application/json"
-    }
+    },
+    "body": "{\"status\": 404, \"developerMessage\": \"NSI with id 1234 not found\"}"
   }
 }

--- a/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_404_X320741_unknown_breach_id.json
+++ b/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_404_X320741_unknown_breach_id.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/secure/offenders/crn/CRNXXX/convictions/2500295343",
+    "urlPath": "/secure/offenders/crn/X320741/convictions/2500295343/nsis/0",
     "headers" : {
       "Content-Type": {
         "equalTo": "application/json"
@@ -13,6 +13,6 @@
     "headers": {
       "Content-Type": "application/json"
     },
-    "body": "{\n    \"status\": 404,\n    \"developerMessage\": \"Offender with crn CRNXXX not found\"\n}"
+    "body": "{\"status\": 404, \"developerMessage\": \"NSI with id 0 not found\"}"
   }
 }

--- a/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_server_error_X320741.json
+++ b/src/test/resources/mocks/mappings/offender-nsis/GET_nsi_server_error_X320741.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/secure/offenders/crn/CRNXXX/convictions/2500295343",
+    "urlPath": "/secure/offenders/crn/X320741/convictions/2500295343/nsis/500",
     "headers" : {
       "Content-Type": {
         "equalTo": "application/json"
@@ -9,10 +9,9 @@
     }
   },
   "response": {
-    "status": 404,
+    "status": 500,
     "headers": {
       "Content-Type": "application/json"
-    },
-    "body": "{\n    \"status\": 404,\n    \"developerMessage\": \"Offender with crn CRNXXX not found\"\n}"
+    }
   }
 }


### PR DESCRIPTION
The problem was an incorrect path (in application YML and wiremock tests) for the court appearances so I have fixed this. There are also now 4 integration tests instead of the 2 we had before.