### PR TITLE
Pic 909 file size download

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
@@ -35,7 +35,7 @@ public class DocumentRestClient {
     private DocumentMapper documentMapper;
 
     @Autowired
-    @Qualifier("communityApiClient")
+    @Qualifier("documentApiClient")
     private RestClientHelper clientHelper;
 
     public Mono<GroupedDocuments> getDocumentsByCrn(String crn) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/DocumentRestClient.java
@@ -53,7 +53,7 @@ public class DocumentRestClient {
         // Unlike retrieve(), exchange() does not throw exceptions which means we have to handle our own
         final Mono<ResponseEntity<Resource>> resourceMono = clientHelper.get(String.format(offenderDocumentUrlTemplate, crn, documentId), MediaType.ALL)
             .exchange()
-            .doOnError(e -> log.error(String.format("Unexpected exception when retrieving offender data for CRN '%s'", crn), e))
+            .doOnError(e -> log.error(String.format("Unexpected exception when retrieving offender document ID '%s' for CRN '%s'", documentId, crn), e))
             .flatMap(clientResponse -> clientResponse.toEntity(Resource.class));
 
         // This puts work off to another thread and therefore won't block

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,7 @@ web:
     connect-timeout-ms: 20000
     read-timeout-ms: 5000
     write-timeout-ms: 5000
+    document-byte-buffer-size: 20971520
 
 hibernate:
   types:


### PR DESCRIPTION
The document is streamed and you need to give spring / reactor a buffer size in the decoder. By default this is 262144 as given in AbstractDataBufferDecoder. So as to not change the value in other webclients, added a specific new one for the documents. Others will continue to work with the same values.