### PR TITLE
💚 PIC-1017: Remove modsecurity snippet from ingress

### DIFF
--- a/helm_deploy/court-case-service/templates/ingress.yaml
+++ b/helm_deploy/court-case-service/templates/ingress.yaml
@@ -14,23 +14,6 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     {{ if .Values.ingress.enable_whitelist }}nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.whitelist | quote }}{{ end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
-      SecRuleEngine On
-      SecAuditEngine RelevantOnly
-      SecAuditLog /var/log/nginx/error.log
-      SecAuditLogType Serial
-      SecRequestBodyLimit 104857600
-      SecRuleUpdateActionById 949110 "t:none,pass"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406"
-      SecAction \
-        "id:900000,\
-         phase:1,\
-         nolog,\
-         pass,\
-         t:none,\
-         setvar:tx.paranoia_level=2"
 spec:
   tls:
   {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
This is a temporary removal as this method is no longer supported by Cloud Platform. Have raised [PIC-1018](https://dsdmoj.atlassian.net/browse/PIC-1018) to reintroduce once the migration has been completed