### PR TITLE
🐛 PIC-1102: Fix for session date/time updates not being reflected by …

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
@@ -12,36 +12,39 @@ import java.util.Optional;
 @Repository
 public interface CourtCaseRepository extends CrudRepository<CourtCaseEntity, Long> {
     @Query(value = "select cc.*, grouped_cases.min_created as first_created from court_case cc " +
-            "inner join (select max(created) as max_created,  min(created) as min_created, case_no from court_case group_cc " +
+            "inner join (select max(created) as max_created,  min(created) as min_created, case_no, court_code from court_case group_cc " +
             "where group_cc.case_no = :caseNo " +
             "and group_cc.court_code = :courtCode " +
             "group by case_no, court_code) grouped_cases " +
             "on cc.case_no = grouped_cases.case_no " +
-            "and cc.created = grouped_cases.max_created " +
+            "and cc.court_code = grouped_cases.court_code " +
+            "where cc.created = grouped_cases.max_created " +
             "and cc.deleted = false",
             nativeQuery = true)
     Optional<CourtCaseEntity> findByCourtCodeAndCaseNo(String courtCode, String caseNo);
 
     @Query(value = "select cc.*, grouped_cases.min_created as first_created from court_case cc " +
-            "inner join (select min(created) as min_created, max(created) as max_created, case_no from court_case group_cc " +
-            "where session_start_time >= :sessionStartAfter " +
-            "and session_start_time < :sessionStartBefore " +
-            "and created >= :createdAfter " +
+            "inner join (select min(created) as min_created, max(created) as max_created, case_no, court_code from court_case group_cc " +
+            "where created >= :createdAfter " +
             "and group_cc.court_code = :courtCode " +
             "group by case_no, court_code) grouped_cases " +
             "on cc.case_no = grouped_cases.case_no " +
+            "and cc.court_code = grouped_cases.court_code " +
+            "where session_start_time >= :sessionStartAfter " +
+            "and session_start_time < :sessionStartBefore " +
             "and cc.created = grouped_cases.max_created " +
             "and cc.deleted = false",
             nativeQuery = true)
     List<CourtCaseEntity> findByCourtCodeAndSessionStartTime(String courtCode, LocalDateTime sessionStartAfter, LocalDateTime sessionStartBefore, LocalDateTime createdAfter);
 
     @Query(value = "select cc.*, grouped_cases.min_created as first_created from court_case cc "
-            + "inner join (select min(created) as min_created, max(created) as max_created, case_no from court_case group_cc "
+            + "inner join (select min(created) as min_created, max(created) as max_created, case_no, court_code from court_case group_cc "
             + "where crn = :crn "
             + "and case_no != :caseNo "
-            + "and session_start_time >= current_date "
             + "group by case_no, court_code) grouped_cases "
             + "on cc.case_no = grouped_cases.case_no "
+            + "and cc.court_code = grouped_cases.court_code "
+            + "where session_start_time >= current_date "
             + "and cc.created = grouped_cases.max_created "
             + "and cc.deleted = false",
             nativeQuery= true)

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -33,6 +33,13 @@ INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court
 INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
 now());
 
+-- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
+-- These cases simulate when a case has been moved to a future date, in this case it should no longer appear in the old case list
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (5555557, 1600028921, 'B10JQ', 1,'2020-02-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-15 00:00:00');
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (5555557, 1600028921, 'B10JQ', 1,'2019-12-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-14 00:00:00');
+
 -- These records are used to test soft deletion
 INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted) VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
 '2020-10-01 16:59:59', false);


### PR DESCRIPTION
…get cases endpoint

The get case list endpoint was filtering by session start time in the wrong SQL select statement meaning that for a given court_code/case_no combination where the case had been moved to a future date it would erroneously keep returning the case on the original date. 

The fix means that it should now only return a given case on the date given in the most recent update.