### PR TITLE
🔧 PIC-871 change targetCPUUtilizationPercentage following guidance

### DIFF
--- a/helm_deploy/court-case-service/templates/hpa.yaml
+++ b/helm_deploy/court-case-service/templates/hpa.yaml
@@ -14,4 +14,4 @@ spec:
     name: {{ template "app.name" . }}
   minReplicas: {{ .Values.minReplicaCount }}
   maxReplicas: {{ .Values.maxReplicaCount }}
-  targetCPUUtilizationPercentage: 50
+  targetCPUUtilizationPercentage: 100


### PR DESCRIPTION
The HPA uses requests instead of limits for its calculation. Our pods have already been reserved 10m so that is guaranteed resource. We should only scale if it gets to 100% - this will allow for better down-scaling.
Done some tests now - on dev

```

  Normal  SuccessfulRescale  43m                  horizontal-pod-autoscaler  New size: 4; reason: All metrics below target
  Normal  SuccessfulRescale  40m                  horizontal-pod-autoscaler  New size: 3; reason: All metrics below target
  Normal  SuccessfulRescale  39m                  horizontal-pod-autoscaler  New size: 6; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  30m (x2 over 57m)    horizontal-pod-autoscaler  New size: 7; reason: All metrics below target
  Normal  SuccessfulRescale  25m (x2 over 50m)    horizontal-pod-autoscaler  New size: 5; reason: All metrics below target
  Normal  SuccessfulRescale  19m (x3 over 3h34m)  horizontal-pod-autoscaler  New size: 8; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  48s (x2 over 73m)    horizontal-pod-autoscaler  New size: 2; reason: Current number of replicas above Spec.MaxReplicas
```
