### PR TITLE
✨ PIC-1144 when CustodialStatus code is unknown - fix NPE

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClient.java
@@ -51,7 +51,7 @@ public class ConvictionRestClient {
             .bodyToMono(CommunityApiAttendances.class)
             // TODO: doOnError will swallow the exception and fail later - use onErrorMap
             .doOnError(e -> log.error(String.format(ERROR_MSG_FORMAT, "sentence attendance", crn, convictionId), e))
-            .map(attendances -> AttendanceMapper.attendancesFrom(attendances));
+            .map(AttendanceMapper::attendancesFrom);
     }
 
 
@@ -94,7 +94,7 @@ public class ConvictionRestClient {
                 var code = Optional.ofNullable(custodialStatusResponse.getCustodialType()).map(KeyValue::getCode).orElse(null);
                 return Optional.ofNullable(code)
                     .map(CustodialStatus::fromString)
-                    .orElse(null);
+                    .orElse(CustodialStatus.UNKNOWN);
             })
             ;
     }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/CustodialStatus.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/CustodialStatus.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.probation.courtcaseservice.service.model;
 
-import java.util.Arrays;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public enum CustodialStatus {
@@ -14,7 +12,9 @@ public enum CustodialStatus {
     MIGRATED_DATA("-1"),
     IN_CUSTODY_RoTL("R"),
     IN_CUSTODY_IRC("I"),
-    AUTO_TERMINATED("AT");
+    AUTO_TERMINATED("AT"),
+    NOT_IN_CUSTODY("NOT_IN_CUSTODY"),
+    UNKNOWN("");
 
     private final String code;
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/ConvictionRestClientIntTest.java
@@ -108,6 +108,14 @@ public class ConvictionRestClientIntTest extends BaseIntTest {
         assertThat(response.get()).isSameAs(CustodialStatus.POST_SENTENCE_SUPERVISION);
     }
 
+    @Test
+    public void givenUnknownStatus_whenGetCustodialStatusByCrnAndConvictionId_thenReturn() {
+        final Optional<CustodialStatus> response = webTestClient.getCustodialStatus("E396405", 1502992087L).blockOptional();
+
+        assertThat(response).isPresent();
+        assertThat(response.get()).isSameAs(CustodialStatus.UNKNOWN);
+    }
+
     @Test(expected = WebClientResponseException.class)
     public void givenServiceThrowsError_whenGetCustodialStatusByCrnCalled_thenFailFastAndThrowException() {
         webTestClient.getCustodialStatus(SERVER_ERROR_CRN, SOME_CONVICTION_ID).block();

--- a/src/test/resources/mocks/__files/offender-currentOrderHeaderDetail/GET_currentOrderHeaderDetail_NotInCustody_E396405.json
+++ b/src/test/resources/mocks/__files/offender-currentOrderHeaderDetail/GET_currentOrderHeaderDetail_NotInCustody_E396405.json
@@ -1,0 +1,16 @@
+{
+  "sentenceId": 1502924527,
+  "custodialType": {
+    "code": "XXXXX",
+    "description": "Some other code"
+  },
+  "sentence": {
+    "description": "ORA Community Order"
+  },
+  "mainOffence": {
+    "description": "Harassment, alarm or distress (Public Order Act 1986) - 12512"
+  },
+  "sentenceDate": "2020-10-07",
+  "length": 3,
+  "lengthUnit": "Months"
+}

--- a/src/test/resources/mocks/mappings/offender-custodialStatus/GET_custodialStatus_success_E396405.json
+++ b/src/test/resources/mocks/mappings/offender-custodialStatus/GET_custodialStatus_success_E396405.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/secure/offenders/crn/E396405/convictions/1502992087/sentenceStatus",
+    "headers" : {
+      "Content-Type": {
+        "equalTo": "application/json"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "offender-currentOrderHeaderDetail/GET_currentOrderHeaderDetail_NotInCustody_E396405.json"
+  }
+}


### PR DESCRIPTION
The incoming code was NOT_IN_CUSTODY which was not in our enum. I have added this but the new test is based on a code which is also not in the enum. No longer a null pointer.