### PR TITLE
✨ allow probation status to be null and handle "Possible nDelius record"

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
@@ -16,6 +16,7 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderMatchEntity;
 
 public class CourtCaseResponseMapper {
+
     public static CourtCaseResponse mapFrom(CourtCaseEntity courtCaseEntity, GroupedOffenderMatchesEntity groupedOffenderMatches) {
         return CourtCaseResponse.builder()
                 .caseId(courtCaseEntity.getCaseId())
@@ -28,7 +29,7 @@ public class CourtCaseResponseMapper {
                 .courtCode(courtCaseEntity.getCourtCode())
                 .offences(mapOffencesFrom(courtCaseEntity))
                 .previouslyKnownTerminationDate(courtCaseEntity.getPreviouslyKnownTerminationDate())
-                .probationStatus(ProbationStatus.of(courtCaseEntity.getProbationStatus()))
+                .probationStatus(Optional.ofNullable(courtCaseEntity.getProbationStatus()).map(ProbationStatus::of).orElse(null))
                 .sessionStartTime(courtCaseEntity.getSessionStartTime())
                 .session(courtCaseEntity.getSession())
                 .suspendedSentenceOrder(courtCaseEntity.getSuspendedSentenceOrder())
@@ -76,4 +77,5 @@ public class CourtCaseResponseMapper {
                 .sequenceNumber(offenceEntity.getSequenceNumber())
                 .build();
     }
+
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
@@ -3,7 +3,9 @@ package uk.gov.justice.probation.courtcaseservice.controller.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,6 +24,9 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.NamePropertiesEntity
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CourtCaseResponse {
+
+    private static final String POSSIBLE_NDELIUS_RECORD_PROBATION_STATUS = "Possible nDelius record";
+
     private final String caseId;
     private final String caseNo;
     private final String crn;
@@ -48,7 +53,14 @@ public class CourtCaseResponse {
     private final String nationality2;
     private final boolean createdToday;
     private final boolean removed;
-    private final Long numberOfPossibleMatches;
+    private final long numberOfPossibleMatches;
+
+    @JsonProperty
+    public String getProbationStatus() {
+        return Optional.ofNullable(probationStatus)
+                .map(ProbationStatus::getName)
+                .orElse(crn == null && numberOfPossibleMatches >= 1 ? POSSIBLE_NDELIUS_RECORD_PROBATION_STATUS : ProbationStatus.NO_RECORD.getName());
+    }
 }
 
 

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
@@ -64,7 +64,7 @@ public class CourtCaseEntity extends BaseImmutableEntity implements Serializable
     @Column(name = "SESSION_START_TIME", nullable = false)
     private final LocalDateTime sessionStartTime;
 
-    @Column(name = "PROBATION_STATUS", nullable = false)
+    @Column(name = "PROBATION_STATUS")
     private final String probationStatus;
 
     @Column(name = "PREVIOUSLY_KNOWN_TERMINATION_DATE")

--- a/src/main/resources/db/migration/courtcase/V1122__alter_probation_status.sql
+++ b/src/main/resources/db/migration/courtcase/V1122__alter_probation_status.sql
@@ -1,0 +1,8 @@
+BEGIN;
+ALTER TABLE court_case ALTER COLUMN probation_status DROP NOT NULL;
+update court_case set probation_status = 'CURRENT' where LOWER(probation_status) = 'current';
+update court_case set probation_status = 'NO_RECORD' where LOWER(probation_status) = 'no record';
+update court_case set probation_status = 'PREVIOUSLY_KNOWN' where LOWER(probation_status) = 'previously known';
+update court_case set probation_status = null where lower(probation_status) like 'possible%';
+COMMIT;
+

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -37,7 +37,7 @@ public class CourtCaseControllerIntTest extends uk.gov.justice.probation.courtca
     CourtCaseRepository courtCaseRepository;
 
     private static final String CASE_NO = "1600028913";
-    private static final String PROBATION_STATUS = "Previously known";
+    private static final String PROBATION_STATUS = "Possible nDelius record";
     private static final String NOT_FOUND_COURT_CODE = "LPL";
 
     @Test
@@ -62,7 +62,7 @@ public class CourtCaseControllerIntTest extends uk.gov.justice.probation.courtca
                 .body("cases[1].offences", hasSize(2))
                 .body("cases[1].caseNo", equalTo("1600028913"))
                 .body("cases[1].preSentenceActivity", equalTo(true))
-                .body("cases[1].probationStatus", equalTo("Previously known"))
+                .body("cases[1].probationStatus", equalTo("Possible nDelius record"))
                 .body("cases[1].offences[0].sequenceNumber", equalTo(1))
                 .body("cases[1].offences[1].sequenceNumber", equalTo(2))
                 .body("cases[1].numberOfPossibleMatches", equalTo(3))
@@ -228,7 +228,7 @@ public class CourtCaseControllerIntTest extends uk.gov.justice.probation.courtca
                 .body("suspendedSentenceOrder", equalTo(true))
                 .body("breach", equalTo(true))
                 .body("preSentenceActivity", equalTo(true))
-                .body("crn", equalTo("X320741"))
+                .body("crn", equalTo(null))
                 .body("cro", equalTo("311462/13E"))
                 .body("pnc", equalTo("A/1234560BA"))
                 .body("listNo", equalTo("3rd"))

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
@@ -87,7 +87,7 @@ class CourtCaseResponseMapperTest {
         assertThat(courtCaseResponse.getCourtCode()).isEqualTo(COURT_CODE);
         assertThat(courtCaseResponse.getCourtRoom()).isEqualTo(COURT_ROOM);
         assertThat(courtCaseResponse.getPreviouslyKnownTerminationDate()).isEqualTo(PREVIOUSLY_KNOWN_TERMINATION_DATE);
-        assertThat(courtCaseResponse.getProbationStatus()).isSameAs(ProbationStatus.NOT_SENTENCED);
+        assertThat(courtCaseResponse.getProbationStatus()).isSameAs(ProbationStatus.NOT_SENTENCED.getName());
         assertThat(courtCaseResponse.getSuspendedSentenceOrder()).isEqualTo(SUSPENDED_SENTENCE_ORDER);
         assertThat(courtCaseResponse.getBreach()).isEqualTo(BREACH);
         assertThat(courtCaseResponse.getPreSentenceActivity()).isEqualTo(PRE_SENTENCE_ACTIVITY);

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponseTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponseTest.java
@@ -33,17 +33,17 @@ class CourtCaseResponseTest {
             .numberOfPossibleMatches(3)
             .build();
 
-        assertThat(response.getProbationStatus()).isEqualTo(ProbationStatus.NOT_SENTENCED.getName());
+        assertThat(response.getProbationStatus()).isEqualTo("No record");
     }
 
     @Test
     void givenMatchedCase_whenGetProbationStatusCurrent_thenReturnName() {
         CourtCaseResponse response = CourtCaseResponse.builder()
             .crn("X340741")
-            .probationStatus(ProbationStatus.NOT_SENTENCED)
+            .probationStatus(ProbationStatus.CURRENT)
             .numberOfPossibleMatches(3)
             .build();
 
-        assertThat(response.getProbationStatus()).isEqualTo("No record");
+        assertThat(response.getProbationStatus()).isEqualTo("Current");
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponseTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponseTest.java
@@ -1,0 +1,49 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourtCaseResponseTest {
+
+    @Test
+    void givenUnmatchedCaseWithMatches_whenGetProbationStatus_thenReturnPossible() {
+        CourtCaseResponse response = CourtCaseResponse.builder()
+            .numberOfPossibleMatches(3)
+            .build();
+
+        assertThat(response.getProbationStatus()).isEqualTo("Possible nDelius record");
+    }
+
+    @Test
+    void givenMatchedCaseWithMatches_whenGetProbationStatus_thenReturnNoRecord() {
+        CourtCaseResponse response = CourtCaseResponse.builder()
+            .crn("X340741")
+            .numberOfPossibleMatches(3)
+            .build();
+
+        assertThat(response.getProbationStatus()).isEqualTo("No record");
+    }
+
+    @Test
+    void givenMatchedCase_whenGetProbationStatus_thenReturnName() {
+        CourtCaseResponse response = CourtCaseResponse.builder()
+            .crn("X340741")
+            .probationStatus(ProbationStatus.NOT_SENTENCED)
+            .numberOfPossibleMatches(3)
+            .build();
+
+        assertThat(response.getProbationStatus()).isEqualTo(ProbationStatus.NOT_SENTENCED.getName());
+    }
+
+    @Test
+    void givenMatchedCase_whenGetProbationStatusCurrent_thenReturnName() {
+        CourtCaseResponse response = CourtCaseResponse.builder()
+            .crn("X340741")
+            .probationStatus(ProbationStatus.NOT_SENTENCED)
+            .numberOfPossibleMatches(3)
+            .build();
+
+        assertThat(response.getProbationStatus()).isEqualTo("No record");
+    }
+}

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -9,7 +9,7 @@ INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('Leicester', '
 INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('Aberystwyth', 'B63AD');
 INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('New New York', 'B30NY');
 
-INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created) VALUES (1700028913, 5555555, 1600028913, 'B10JQ', 1, '2019-12-14 09:00', 'PREVIOUSLY_KNOWN', '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'X320741', 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now());
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created) VALUES (1700028913, 5555555, 1600028913, 'B10JQ', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now());
 
 -- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnCasesForToday()
 -- These records are used to test edge cases when returning court case list for a given date (midnight to 1 second before midnight the next day)
@@ -24,18 +24,18 @@ INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court
 '2020-09-01 16:59:59');
 INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'CURRENT', 'X320745', 'Mr Hideo Kojima',
 '2020-10-01 16:59:59');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'No record', 'X320745', 'Mr Hideo Kojima',
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'NO_RECORD', 'X320745', 'Mr Hideo Kojima',
 '2020-10-01 18:59:59');
 
 
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, created_by) VALUES (5555560, 1600028919, 'B30NY', 1, '2019-12-14 12:59:59', 'No record', 'X320654', 'Hubert Farnsworth',
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, created_by) VALUES (5555560, 1600028919, 'B30NY', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320654', 'Hubert Farnsworth',
 '2020-10-01 16:59:59', 'TURANGALEE(prepare-a-case)');
 
 -- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
 -- These records are used to test that the createdToday field returns false if a new record was created today updating an existing one
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie',
 '2020-10-01 16:59:59');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
+INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie',
 now());
 
 -- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()


### PR DESCRIPTION
The CourtCaseResponse has a string for probation status and it has a getter method to determine if it is null / unmatched then can return "Possible nDelius record". So we don't store that value in the database anymore. PROBATION_STATUS can be null in these cases. Also is some migration. 
Fixed integration tests. 