### PR TITLE
📈 PIC-1270: Log deployment message with version on application start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
 
 def today = Instant.now()
 def todaysDate = LocalDate.now().format('yyyy-MM-dd')
-version = System.getenv('CI') ? "${todaysDate}.${System.getenv('CIRCLE_BUILD_NUM')}" : todaysDate
+def appVersion = System.getenv('CI') ? "${todaysDate}.${System.getenv('CIRCLE_BUILD_NUM')}" : todaysDate
 
 configurations {
     compileOnly {
@@ -50,6 +50,10 @@ jar {
     }
 }
 
+bootJar {
+    manifest = jar.manifest
+}
+
 flyway {
     url = 'jdbc:postgresql://localhost:5432/postgres?currentSchema=courtcaseservice&user=root&password=dev'
 }
@@ -58,7 +62,7 @@ springBoot {
     buildInfo {
         properties {
             artifact = rootProject.name
-            version = version
+            version = appVersion
             group = group
             name = rootProject.name
             time = today

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
 
 def today = Instant.now()
 def todaysDate = LocalDate.now().format('yyyy-MM-dd')
-def appVersion = System.getenv('CI') ? "${todaysDate}.${System.getenv('CIRCLE_BUILD_NUM')}" : todaysDate
+version = System.getenv('CI') ? "${todaysDate}.${System.getenv('CIRCLE_BUILD_NUM')}" : todaysDate
 
 configurations {
     compileOnly {
@@ -62,7 +62,7 @@ springBoot {
     buildInfo {
         properties {
             artifact = rootProject.name
-            version = appVersion
+            version = version
             group = group
             name = rootProject.name
             time = today

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/DeploymentLogger.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/DeploymentLogger.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.probation.courtcaseservice;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+@Component
+@Slf4j
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeploymentLogger {
+
+    @Autowired
+    private BuildProperties buildProperties;
+
+    @EventListener
+    public void onApplicationEvent(ApplicationReadyEvent readyEvent) throws UnknownHostException {
+        log.info(String.format("Starting CourtCaseServiceApplication %s using Java %s on %s", buildProperties.getVersion(), System.getProperty("java.version"), Optional.ofNullable(InetAddress.getLocalHost()).map(InetAddress::getHostName).orElse("unknown machine")));
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/DeploymentLoggerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/DeploymentLoggerTest.java
@@ -22,6 +22,7 @@ class DeploymentLoggerTest {
         when(buildProperties.getVersion()).thenReturn("expected_version");
         final var logger = new DeploymentLogger(buildProperties);
 
+        TestAppender.events.clear();
         logger.onApplicationEvent(null);
         assertThat(TestAppender.events.size()).isEqualTo(1);
         assertThat(TestAppender.events.get(0).toString()).startsWith("[INFO] Starting CourtCaseServiceApplication expected_version using Java ");

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/DeploymentLoggerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/DeploymentLoggerTest.java
@@ -1,0 +1,30 @@
+package uk.gov.justice.probation.courtcaseservice;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.info.BuildProperties;
+
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeploymentLoggerTest {
+
+    @Mock
+    private BuildProperties buildProperties;
+
+    @Test
+    public void shouldLogInfo() throws UnknownHostException {
+        when(buildProperties.getVersion()).thenReturn("expected_version");
+        final var logger = new DeploymentLogger(buildProperties);
+
+        logger.onApplicationEvent(null);
+        assertThat(TestAppender.events.size()).isEqualTo(1);
+        assertThat(TestAppender.events.get(0).toString()).startsWith("[INFO] Starting CourtCaseServiceApplication expected_version using Java ");
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/TestAppender.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/TestAppender.java
@@ -1,0 +1,16 @@
+package uk.gov.justice.probation.courtcaseservice;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestAppender extends AppenderBase<LoggingEvent> {
+    static List<LoggingEvent> events = new ArrayList<>();
+
+    @Override
+    protected void append(LoggingEvent e) {
+        events.add(e);
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m | %mdc %n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <springProperty scope="context" name="app" source="spring.application.name"/>
+
+    <appender name="testAppender" class="uk.gov.justice.probation.courtcaseservice.TestAppender"/>
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="consoleAppender"/>
+        <appender-ref ref="testAppender"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Not particularly happy with this as a solution but it works. Spring ought to log the version automatically from what I can tell but for reasons I don't understand it isn't. In the end I've taken the pragmatic approach and just logged it again as I managed to do that in less time than it took me debugging why it wasn't working in the first place 🙄