### PR TITLE
Pic 959 contract provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ jobs:
               PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
               PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="<< parameters.consumer_tags >>" \
               PACT_PUBLISH_RESULTS="true" \
+              SPRING_PROFILES_ACTIVE="unsecured" \
               ./gradlew pactTestPublish
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ workflows:
           requires:
             - request_prod_approval
 
-#  pact:
-#    jobs:
-#      - pact_check_and_publish:
-#          consumer_tags: << pipeline.parameters.pact_consumer_tags >>
+  pact:
+    jobs:
+      - pact_check_and_publish:
+          consumer_tags: << pipeline.parameters.pact_consumer_tags >>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.38.0'
     id "org.flywaydb.flyway" version "7.8.1"
     id 'jacoco'
-    id "au.com.dius.pact" version "4.2.2"
+    id "au.com.dius.pact" version "4.2.5"
     id 'java-library'
 }
 
@@ -31,7 +31,7 @@ group = 'uk.gov.justice.probation'
 ext {
     swaggerVersion = '2.9.2'
     restAssuredVersion = '4.2.0'
-    pactVersion = '4.2.2'
+    pactVersion = '4.2.5'
 }
 
 def today = Instant.now()
@@ -113,7 +113,7 @@ task pactTestPublish(type: Test) {
     useJUnitPlatform ()
     filter {
         excludeTestsMatching '*IntTest'
-        includeTestsMatching '*VerificationPactTest'
+        includeTestsMatching '*PrepareACaseConsumerVerificationPactTest'
     }
 
     systemProperty("pact.provider.tag", System.getenv("PACT_PROVIDER_TAG"))

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/security/OAuth2SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/security/OAuth2SecurityConfig.java
@@ -1,11 +1,13 @@
 package uk.gov.justice.probation.courtcaseservice.security;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 
 @EnableWebSecurity
+@Profile("!unsecured")
 public class OAuth2SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/application/UnsecuredResourceServerConfiguration.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/application/UnsecuredResourceServerConfiguration.java
@@ -1,14 +1,15 @@
-package uk.gov.justice.probation.courtcaseservice.pact;
+package uk.gov.justice.probation.courtcaseservice.application;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 
 @Configuration
-@Order(99)
-public class TestSecurity extends WebSecurityConfigurerAdapter {
+@Profile("unsecured")
+public class UnsecuredResourceServerConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/CourtCaseMatcherVerificationPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/CourtCaseMatcherVerificationPactTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
+import uk.gov.justice.probation.courtcaseservice.application.UnsecuredResourceServerConfiguration;
 import uk.gov.justice.probation.courtcaseservice.controller.model.GroupedOffenderMatchesRequest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 @Provider("court-case-service")
 @PactBroker
-@Import(TestSecurity.class)
+@Import(UnsecuredResourceServerConfiguration.class)
 @Disabled
 class CourtCaseMatcherVerificationPactTest extends BaseIntTest {
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/CourtCaseMatcherVerificationPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/CourtCaseMatcherVerificationPactTest.java
@@ -14,10 +14,9 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
-import uk.gov.justice.probation.courtcaseservice.application.UnsecuredResourceServerConfiguration;
 import uk.gov.justice.probation.courtcaseservice.controller.model.GroupedOffenderMatchesRequest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
@@ -31,8 +30,8 @@ import static org.mockito.Mockito.when;
 
 @Provider("court-case-service")
 @PactBroker
-@Import(UnsecuredResourceServerConfiguration.class)
 @Disabled
+@ActiveProfiles("unsecured")
 class CourtCaseMatcherVerificationPactTest extends BaseIntTest {
 
     @MockBean

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/PrepareACaseConsumerVerificationPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/pact/PrepareACaseConsumerVerificationPactTest.java
@@ -2,7 +2,9 @@ package uk.gov.justice.probation.courtcaseservice.pact;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.Month;
+import java.util.Collections;
 import java.util.List;
 import au.com.dius.pact.provider.junit5.HttpTestTarget;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
@@ -14,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
@@ -70,8 +71,11 @@ class PrepareACaseConsumerVerificationPactTest extends BaseIntTest {
     @State({"a list of cases exist for the given date",
         "a case exists with the given case number",
         "the defendant has possible matches with existing offender records",
-        "the defendant has an existing conviction",
-        "will return the specific conviction breach details"})
+        "the defendant has an existing conviction with sentence",
+        "a defendant has an existing conviction",
+        "will return the specific conviction breach details",
+        "a defendant has an existing conviction"})
+    @SuppressWarnings({"EmptyMethod"})
     void stateFromIntegrationTests() {
     }
 
@@ -157,20 +161,8 @@ class PrepareACaseConsumerVerificationPactTest extends BaseIntTest {
                 .completedDate(LocalDateTime.of(2018, Month.FEBRUARY, 28, 0, 0,0)).build())
             .build();
 
-        var breach1 = Breach.builder()
-            .breachId(11131322L)
-            .description("Community Order")
-            .status("Breach Initiated")
-            .started(LocalDate.of(2020, Month.OCTOBER, 20))
-            .statusDate(LocalDate.of(2020, Month.DECEMBER, 18))
-            .build();
-        var breach2 = Breach.builder()
-            .breachId(11131321L)
-            .description("Community Order")
-            .status("Breach Initiated")
-            .started(LocalDate.of(2019, Month.OCTOBER, 20))
-            .statusDate(LocalDate.of(2019, Month.DECEMBER, 18))
-            .build();
+        var breachStartDate = LocalDate.of(2020, Month.OCTOBER, 20);
+        var breachStatusDate = LocalDate.of(2020, Month.DECEMBER, 18);
 
         var conviction = Conviction.builder()
             .convictionId("2500295345")
@@ -181,7 +173,7 @@ class PrepareACaseConsumerVerificationPactTest extends BaseIntTest {
             .sentence(sentence)
             .endDate(LocalDate.of(2019, Month.JANUARY, 1))
             .documents(List.of(document))
-            .breaches(List.of(breach1, breach2))
+            .breaches(List.of(getBreach(11131322L, breachStartDate, breachStatusDate), getBreach(11131321L, breachStartDate.minusYears(1), breachStatusDate.minusYears(1))))
             .build();
 
         var probationRecord = ProbationRecord.builder()
@@ -204,7 +196,56 @@ class PrepareACaseConsumerVerificationPactTest extends BaseIntTest {
             .nextReviewDate(LocalDate.of(2019, Month.DECEMBER, 30))
             .notes(List.of("01-01-20 - MAPPA has now ended."))
             .build();
-        when(offenderService.getOffenderRegistrations("D541487")).thenReturn(Mono.just(List.of(reg)));
+        when(offenderService.getOffenderRegistrations("D991494")).thenReturn(Mono.just(List.of(reg)));
     }
 
+    @State({"a defendant has an existing conviction"})
+    void defendantHasAnExistingConviction() {
+        var start = LocalDate.of(2017, Month.JUNE, 1);
+        var end = LocalDate.of(2018, Month.MAY, 31);
+        var breachStartDate = LocalDate.of(2020, Month.OCTOBER, 20);
+        var breachStatusDate = LocalDate.of(2020, Month.DECEMBER, 18);
+
+        var conviction = Conviction.builder()
+            .convictionId("2500295343")
+            .active(Boolean.TRUE)
+            .inBreach(Boolean.FALSE)
+            .convictionDate(start)
+            .endDate(end)
+            .sentence(Sentence.builder()
+                    .description("CJA - Community Order")
+                    .length(12)
+                    .lengthUnits("Months")
+                    .lengthInDays(364)
+                    .terminationDate(LocalDate.of(2017, Month.DECEMBER, 1))
+                    .startDate(start)
+                    .endDate(end)
+                    .terminationReason("Completed - early good progress")
+                    .build())
+            .breaches(List.of(getBreach(11131322L, breachStartDate, breachStatusDate), getBreach(11131321L, breachStartDate.minusYears(1), breachStatusDate.minusYears(1))))
+            .documents(List.of(OffenderDocumentDetail.builder()
+                                .documentId("5058ca66-3751-4701-855a-86bf518d9392")
+                                .documentName("documentName")
+                                .author("Andy Marke")
+                                .type(DocumentType.COURT_REPORT_DOCUMENT)
+                                .createdAt(LocalDateTime.of(LocalDate.of(2019, Month.SEPTEMBER, 4), LocalTime.MIN))
+                                .subType(KeyValue.builder()
+                                    .code("CR02")
+                                    .description("Court Report")
+                                    .build())
+                                .build()))
+            .offences(Collections.emptyList())
+            .build();
+        when(offenderService.getConviction("X320741", 2500295343L)).thenReturn(Mono.just(conviction));
+    }
+
+    private Breach getBreach(Long id, LocalDate startedDate, LocalDate statusDate) {
+        return Breach.builder()
+            .breachId(id)
+            .description("Community Order")
+            .status("Breach Initiated")
+            .started(startedDate)
+            .statusDate(statusDate)
+            .build();
+    }
 }


### PR DESCRIPTION
Verifies and publishes PACT results to the broker. Only prepare-a-case at the moment. court-case-matcher PACTS are not being verified. We may need separate state verification provider classes. 

@jhevans - this doesn't line up 100% with the user-preferences implementation. It does not mix the 4.2.x dependencies with this one. Maybe we should review jointly.
`testImplementation("au.com.dius:pact-jvm-provider-junit5:4.0.10")`