### PR TITLE
✏️ PIC-1406: Update ADR and use default case list Last-Modified date

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ To run build which generates and published the consumer PACTs to the broker, the
 The PACTs can be generated and published, tagged with "main" with the following command
 
 `PACTCONSUMER_VERSION=main ./gradlew -Dpact.writer.overwrite=true test pactPublish`
+
+---
+
+### Caching
+
+The case list page is cacheable and returns a Last-Modified header for cache validation. There is an nginx docker container configured to do this in `./nginx/Dockerfile`.
+
+To build and run the nginx cache against a local instance of court-case-service running on port 8090:
+
+```
+docker build ./nginx --tag court-case-service-proxy
+docker run -p 8080:8080 --env SERVICE_HOST=http://host.docker.internal:8090 court-case-service-proxy
+```
+
+This will act as a simple reverse proxy with caching. It is configured to return an `X-Cache-Status` header which indicates whether the response was retrieved from the cache.

--- a/doc/adr/0004-nginx-caching.md
+++ b/doc/adr/0004-nginx-caching.md
@@ -1,0 +1,20 @@
+# 4. Nginx caching of case list response
+
+Date: 2021-06-07
+
+## Status
+
+Accepted
+
+## Context
+
+The performance of the case list page is currently reasonably slow on account of the complex database queries it entails. It's also central to the user journey and thus has high traffic whilst receiving few updates for most of the day. This makes it a good candidate for caching which should hopefully significantly improve UX whilst reducing load on the court-case-service.  
+
+## Decision
+
+An nginx reverse-proxy will be introduced in front of the court-case-service which will act as a cache. We will make a cheap fast query to determine the last modified date of a case list and returning this in a Last-Modified header, the client (in this case an nginx proxy) can provide this timestamp back to us in an If-Modified-Since header which court-case-service can then use to return a 304 Not Modified status in the case where no changes have been made to that case list. Nginx will then serve a cached response having validated it is still fresh. 
+
+## Consequences
+
+- Speed of response on repeat calls for a case list should improve drastically
+- If a court has no cases for the requested date then Last-Modified will be set to a default date in the past before the service went live (2020-01-01). This will allow the (empty) case list to be cached. 

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -31,13 +31,13 @@ import uk.gov.justice.probation.courtcaseservice.service.OffenderMatchService;
 import javax.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static java.time.LocalTime.MIDNIGHT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Api(tags = "Court and Cases Resources")
@@ -47,6 +47,7 @@ public class CourtCaseController {
 
     // See https://www.postgresql.org/docs/9.0/datatype-datetime.html
     private static final int MAX_YEAR_SUPPORTED_BY_DB = 294276;
+    private static final LocalDateTime NEVER_MODIFIED_DATE = LocalDateTime.of(2020, 1, 1, 0, 0);
     private final CourtCaseService courtCaseService;
     private final OffenderMatchService offenderMatchService;
 
@@ -113,7 +114,7 @@ public class CourtCaseController {
             WebRequest webRequest
     ) {
         var lastModified = courtCaseService.filterCasesLastModified(courtCode, date)
-            .orElse(LocalDateTime.now())
+            .orElse(NEVER_MODIFIED_DATE)
             .toInstant(ZoneOffset.UTC);
         if (webRequest.checkNotModified(lastModified.toEpochMilli())) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
@@ -121,7 +122,7 @@ public class CourtCaseController {
 
         final var createdAfterOrDefault = Optional.ofNullable(createdAfter)
                 .orElse(
-                        LocalDateTime.of(date, LocalTime.MIDNIGHT).minusDays(8)
+                        LocalDateTime.of(date, MIDNIGHT).minusDays(8)
                 );
 
         final var createdBeforeOrDefault = Optional.ofNullable(createdBefore)


### PR DESCRIPTION
When going through the ADR it occurred to me that we can do better than just logging "now" as the last modified date and allow the client to cache if they want. As long as we consistently keep returning an arbitrary date in the past then it will be guaranteed to update as soon as a new update comes through (because the timestamp will be in the present not the past).

The date I chose is pretty arbitrary but I went for a nice round 2020-01-01 - so before we started getting real data but around the inception of the court-case-service as a thing.