### PR TITLE
🐞PIC-1574 boolean to mark document as a PSR one

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapper.java
@@ -4,10 +4,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiConvictionDocuments;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiOffenderDocumentDetail;
+import uk.gov.justice.probation.courtcaseservice.service.model.KeyValue;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.DocumentType;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
@@ -15,6 +18,10 @@ import uk.gov.justice.probation.courtcaseservice.service.model.document.Offender
 
 @Component
 public class DocumentMapper {
+
+    @Setter
+    @Value("#{'${offender-service.psr-report-codes}'.split(',')}")
+    private List<String> psrTypeCodes;
 
     public GroupedDocuments documentsFrom(CommunityApiGroupedDocumentsResponse documentsResponse) {
         return GroupedDocuments.builder()
@@ -59,7 +66,14 @@ public class DocumentMapper {
             .reportDocumentDates(detail.getReportDocumentDates())
             .subType(detail.getSubType())
             .parentPrimaryKeyId(detail.getParentPrimaryKeyId())
+            .psr(isPsr(detail.getSubType()))
             .build();
+    }
+
+    private boolean isPsr(KeyValue keyValueSubType) {
+        return Optional.ofNullable(keyValueSubType)
+            .map(subType -> psrTypeCodes.contains(subType.getCode()))
+            .orElse(Boolean.FALSE);
     }
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/Conviction.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/Conviction.java
@@ -31,6 +31,7 @@ public class Conviction implements Comparable<Conviction>{
     private final Sentence sentence;
     private final LocalDate endDate;
     private final KeyValue custodialType;
+    @Deprecated(forRemoval = true)
     @Setter
     private List<CourtReport> psrReports;
     @Setter

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/document/OffenderDocumentDetail.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/model/document/OffenderDocumentDetail.java
@@ -27,11 +27,14 @@ public class OffenderDocumentDetail {
     private final DocumentType type;
     private final String extendedDescription;
     private final LocalDateTime createdAt;
+    public final boolean psr;
 
     @JsonIgnore
     private final Long parentPrimaryKeyId;
 
     private final KeyValue subType;
     private final ReportDocumentDates reportDocumentDates;
+
+
 }
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderControllerIntTest.java
@@ -104,6 +104,7 @@ class OffenderControllerIntTest extends BaseIntTest {
                 .body("convictions[0].psrReports[0].author.forenames", equalTo("Unallocated Staff(N02)"))
                 .body("convictions[0].psrReports[0].author.surname", equalTo("Staff"))
                 .body("convictions[0].documents[0].documentId", equalTo("1d842fce-ec2d-45dc-ac9a-748d3076ca6b"))
+                .body("convictions[0].documents[0].psr", equalTo(true))
                 .body("convictions[0].breaches", hasSize(0))
                 .body("convictions[0].endDate", equalTo(standardDateOf(2019, 1,1)))
                 .body("convictions[0].sentence.endDate", equalTo(standardDateOf(2019, 1,1)))

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/restclient/communityapi/mapper/DocumentMapperTest.java
@@ -13,18 +13,17 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.probation.courtcaseservice.restclient.communityapi.model.CommunityApiGroupedDocumentsResponse;
 import uk.gov.justice.probation.courtcaseservice.service.model.KeyValue;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.ConvictionDocuments;
-import uk.gov.justice.probation.courtcaseservice.service.model.document.GroupedDocuments;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.OffenderDocumentDetail;
 import uk.gov.justice.probation.courtcaseservice.service.model.document.ReportDocumentDates;
 
-public class DocumentMapperTest {
+    class DocumentMapperTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -41,15 +40,16 @@ public class DocumentMapperTest {
     @BeforeEach
     void setUp() {
         mapper = new DocumentMapper();
+        mapper.setPsrTypeCodes(List.of("CJF", "CJO", "CJS", "PSR"));
     }
 
     @DisplayName("Prove that null input lists in the community API will be handled and create empty lists")
     @Test
     void shouldMapGroupedDocumentsWithNullsToEmptyDocumentLists() {
 
-        CommunityApiGroupedDocumentsResponse response = new CommunityApiGroupedDocumentsResponse(null, null);
+        final var response = new CommunityApiGroupedDocumentsResponse(null, null);
 
-        GroupedDocuments groupedDocuments = mapper.documentsFrom(response);
+        final var groupedDocuments = mapper.documentsFrom(response);
 
         assertThat(groupedDocuments.getDocuments()).isEmpty();
         assertThat(groupedDocuments.getConvictions()).isEmpty();
@@ -59,10 +59,10 @@ public class DocumentMapperTest {
     @Test
     void shouldMapGroupedDocumentsToDocuments() throws IOException {
 
-        CommunityApiGroupedDocumentsResponse response
+        final var response
             = OBJECT_MAPPER.readValue(new File(BASE_MOCK_PATH + "offender-documents/GET_documents_success_X320741.json"), CommunityApiGroupedDocumentsResponse.class);
 
-        GroupedDocuments documentsResponse = mapper.documentsFrom(response);
+        final var documentsResponse = mapper.documentsFrom(response);
 
         // Check sizes and one from each collection
         assertThat(documentsResponse.getDocuments()).hasSize(7);
@@ -75,19 +75,21 @@ public class DocumentMapperTest {
                                     "5152b060-9650-4f22-9974-038a38590d9f", "7ceda384-3624-4a62-849d-7c729b6d0dd1",
                                     "2b167448-31a5-45a5-85a5-dcdd4a783f1d");
 
-        OffenderDocumentDetail documentDetail = documentsResponse.getDocuments().stream()
+        final var documentDetail = documentsResponse.getDocuments().stream()
                                                     .filter(doc -> doc.getDocumentId().equals("1e593ff6-d5d6-4048-a671-cdeb8f65608b"))
                                                     .findFirst().get();
-        assertThat(documentDetail).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
-                                                                    .documentId("1e593ff6-d5d6-4048-a671-cdeb8f65608b")
-                                                                    .documentName("PRE-CONS.pdf")
-                                                                    .author("Andy Marke")
-                                                                    .type(PRECONS_DOCUMENT)
-                                                                    .extendedDescription("Previous convictions as of 01/09/2019")
-                                                                    .createdAt(LocalDateTime.of(2019, SEPTEMBER, 10, 0, 0, 0))
-                                                                    .build());
+        assertThat(documentDetail)
+            .usingRecursiveComparison()
+            .isEqualTo(OffenderDocumentDetail.builder()
+                                        .documentId("1e593ff6-d5d6-4048-a671-cdeb8f65608b")
+                                        .documentName("PRE-CONS.pdf")
+                                        .author("Andy Marke")
+                                        .type(PRECONS_DOCUMENT)
+                                        .extendedDescription("Previous convictions as of 01/09/2019")
+                                        .createdAt(LocalDateTime.of(2019, SEPTEMBER, 10, 0, 0, 0))
+                                        .build());
 
-        ConvictionDocuments convictionDocuments1 = documentsResponse.getConvictions().stream()
+        final var convictionDocuments1 = documentsResponse.getConvictions().stream()
             .filter(conviction -> conviction.getConvictionId().equals("2500295343"))
             .findFirst().get();
         assertThat(convictionDocuments1.getDocuments()).hasSize(7);
@@ -98,25 +100,31 @@ public class DocumentMapperTest {
                 "44f37749-18b8-46ff-803a-150746f6d1bc", "b88547cf-7464-4cbc-b5f9-ebe2bafc19d9",
                 "4191eada-6e03-4bd8-b52d-9e050eefa745");
 
-        ConvictionDocuments convictionDocuments2 = documentsResponse.getConvictions().stream()
+        final var convictionDocuments2 = documentsResponse.getConvictions().stream()
             .filter(conviction -> conviction.getConvictionId().equals("2500295345"))
             .findFirst().get();
         assertThat(convictionDocuments2.getDocuments()).hasSize(8);
-        OffenderDocumentDetail preSentenceReport = convictionDocuments2.getDocuments().stream()
+        final var preSentenceReport = convictionDocuments2.getDocuments().stream()
             .filter(document -> document.getDocumentName().startsWith("shortFormatPreSentenceReport"))
             .findFirst().get();
-        assertThat(preSentenceReport).isEqualToComparingFieldByField(OffenderDocumentDetail.builder()
-            .documentId("1d842fce-ec2d-45dc-ac9a-748d3076ca6b")
-            .documentName("shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf")
-            .author("Andy Marke")
-            .type(COURT_REPORT_DOCUMENT)
-            .extendedDescription("Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018")
-            .createdAt(LocalDateTime.of(2019, SEPTEMBER, 4, 0, 0, 0))
-            .subType(new KeyValue("CJF", "Pre-Sentence Report - Fast"))
-            .parentPrimaryKeyId(2500079873L)
-            .reportDocumentDates(new ReportDocumentDates(LocalDate.of(2018, SEPTEMBER, 4), LocalDate.of(2019, SEPTEMBER, 4), LocalDateTime.of(2018, FEBRUARY, 28, 0, 0, 0)))
-            .build());
-
+        assertThat(preSentenceReport)
+            .usingRecursiveComparison()
+            .isEqualTo(OffenderDocumentDetail.builder()
+                            .documentId("1d842fce-ec2d-45dc-ac9a-748d3076ca6b")
+                            .documentName("shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf")
+                            .author("Andy Marke")
+                            .type(COURT_REPORT_DOCUMENT)
+                            .extendedDescription("Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018")
+                            .createdAt(LocalDateTime.of(2019, SEPTEMBER, 4, 0, 0, 0))
+                            .subType(new KeyValue("CJF", "Pre-Sentence Report - Fast"))
+                            .parentPrimaryKeyId(2500079873L)
+                            .reportDocumentDates(ReportDocumentDates.builder()
+                                .requestedDate(LocalDate.of(2018, SEPTEMBER, 4))
+                                .requiredDate(LocalDate.of(2019, SEPTEMBER, 4))
+                                .completedDate(LocalDateTime.of(2018, FEBRUARY, 28, 0, 0, 0))
+                                .build())
+                            .psr(true)
+                            .build());
     }
 
 }


### PR DESCRIPTION
Adds "`psr`" boolean to the documents. The `psrReports` array remains in place but should now be ignored. Subsequent tickets will be raised for prepare a case to use the new boolean and to remove psrReports 