### PR TITLE
✨ PIC-1581 add new JPA entities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'org.springframework.boot' version '2.5.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'com.github.ben-manes.versions' version '0.39.0'
-    id "org.flywaydb.flyway" version "7.12.0"
+    id "org.flywaydb.flyway" version "7.12.1"
     id 'jacoco'
     id "au.com.dius.pact" version "4.2.9"
     id 'java-library'

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
@@ -84,6 +86,18 @@ public class CourtCaseEntity extends BaseImmutableEntity implements Serializable
     @JsonManagedReference
     @OneToMany(mappedBy = "courtCase", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval=true)
     private final List<OffenceEntity> offences;
+
+    // If you have more than one collection with fetch = FetchType.EAGER then there is an exception
+    // org.hibernate.loader.MultipleBagFetchException: cannot simultaneously fetch multiple bags
+    // After CP integration, we will need to look at session boundaries @LazyCollection is one solution
+    @LazyCollection(value = LazyCollectionOption.FALSE)
+    @JsonIgnore
+    @OneToMany(mappedBy = "courtCase", cascade = CascadeType.ALL, orphanRemoval=true)
+    private final List<HearingEntity> hearings;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "courtCase", cascade = CascadeType.ALL, orphanRemoval=true)
+    private final List<DefendantEntity> defendants;
 
     @Column(name = "DEFENDANT_NAME")
     private final String defendantName;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtSession.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtSession.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.jpa.entity;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public enum CourtSession {
     MORNING,
@@ -8,6 +9,10 @@ public enum CourtSession {
 
 
     public static CourtSession from(LocalDateTime sessionStartTime) {
+        return sessionStartTime.getHour() < 12 ? MORNING : AFTERNOON;
+    }
+
+    public static CourtSession from(LocalTime sessionStartTime) {
         return sessionStartTime.getHour() < 12 ? MORNING : AFTERNOON;
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
@@ -75,7 +75,7 @@ public class DefendantEntity extends BaseImmutableEntity implements Serializable
     private final String cro;
 
     @Column(name = "DATE_OF_BIRTH")
-    private final LocalDate defendantDob;
+    private final LocalDate dateOfBirth;
 
     @Column(name = "SEX")
     private final String sex;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
@@ -1,0 +1,89 @@
+package uk.gov.justice.probation.courtcaseservice.jpa.entity;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Type;
+
+@Entity
+@Table(name = "DEFENDANT")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@SuperBuilder
+@Getter
+@ToString(exclude = "courtCase")
+@EqualsAndHashCode(callSuper = true)
+public class DefendantEntity extends BaseImmutableEntity implements Serializable {
+
+    @Id
+    @Column(name = "ID", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
+    private final Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "COURT_CASE_ID", referencedColumnName = "id", nullable = false)
+    @Setter
+    private CourtCaseEntity courtCase;
+
+    @OneToMany(mappedBy = "defendant", cascade = CascadeType.ALL, orphanRemoval=true)
+    private final List<DefendantOffenceEntity> offences;
+
+    @Column(name = "DEFENDANT_NAME", nullable = false)
+    private final String defendantName;
+
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "jsonb", name = "NAME", nullable = false)
+    private final NamePropertiesEntity name;
+
+    @Column(name = "TYPE", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private final DefendantType type;
+
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "jsonb", name = "ADDRESS")
+    private final AddressPropertiesEntity address;
+
+    @Column(name = "CRN")
+    private final String crn;
+
+    @Column(name = "PNC")
+    private final String pnc;
+
+    @Column(name = "CRO")
+    private final String cro;
+
+    @Column(name = "DATE_OF_BIRTH")
+    private final LocalDate defendantDob;
+
+    @Column(name = "SEX")
+    private final String sex;
+
+    @Column(name = "NATIONALITY_1")
+    private final String nationality1;
+
+    @Column(name = "NATIONALITY_2")
+    private final String nationality2;
+
+}

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantOffenceEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantOffenceEntity.java
@@ -1,0 +1,58 @@
+package uk.gov.justice.probation.courtcaseservice.jpa.entity;
+
+import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OrderColumn;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "DEFENDANT_OFFENCE")
+@AllArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Getter
+@ToString(exclude = "defendant")
+@EqualsAndHashCode(callSuper = true)
+public class DefendantOffenceEntity extends BaseImmutableEntity implements Serializable  {
+
+    @Id
+    @Column(name = "ID", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
+    private final Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "DEFENDANT_ID", referencedColumnName = "id", nullable = false)
+    @Setter
+    private DefendantEntity defendant;
+
+    @Column(name = "TITLE", nullable = false)
+    private final String title;
+
+    @Column(name = "SUMMARY", nullable = false)
+    private final String summary;
+
+    @Column(name = "ACT")
+    private final String act;
+
+    @OrderColumn
+    @Column(name = "SEQUENCE", nullable = false)
+    @JsonProperty
+    private final Integer sequence;
+}

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
@@ -1,7 +1,9 @@
 package uk.gov.justice.probation.courtcaseservice.jpa.entity;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -41,8 +43,11 @@ public class HearingEntity extends BaseImmutableEntity implements Serializable {
     @Setter
     private CourtCaseEntity courtCase;
 
-    @Column(name = "SESSION_START_TIME", nullable = false)
-    private final LocalDateTime sessionStartTime;
+    @Column(name = "HEARING_DAY", nullable = false)
+    private final LocalDate hearingDay;
+
+    @Column(name = "HEARING_TIME", nullable = false)
+    private final LocalTime hearingTime;
 
     @Column(name = "COURT_CODE", nullable = false)
     private final String courtCode;
@@ -54,7 +59,7 @@ public class HearingEntity extends BaseImmutableEntity implements Serializable {
     private final String listNo;
 
     public CourtSession getSession() {
-        return CourtSession.from(sessionStartTime);
+        return CourtSession.from(hearingTime);
     }
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.probation.courtcaseservice.jpa.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "HEARING")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@SuperBuilder
+@Getter
+@ToString(exclude = "courtCase")
+@EqualsAndHashCode(callSuper = true)
+public class HearingEntity extends BaseImmutableEntity implements Serializable {
+
+    @Id
+    @Column(name = "ID", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
+    private final Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "COURT_CASE_ID", referencedColumnName = "id", nullable = false)
+    @Setter
+    private CourtCaseEntity courtCase;
+
+    @Column(name = "SESSION_START_TIME", nullable = false)
+    private final LocalDateTime sessionStartTime;
+
+    @Column(name = "COURT_CODE", nullable = false)
+    private final String courtCode;
+
+    @Column(name = "COURT_ROOM", nullable = false)
+    private final String courtRoom;
+
+    @Column(name = "LIST_NO")
+    private final String listNo;
+
+    public CourtSession getSession() {
+        return CourtSession.from(sessionStartTime);
+    }
+
+}

--- a/src/main/resources/db/migration/courtcase/V2000__add_hearing_defendant_newoffence_table.sql
+++ b/src/main/resources/db/migration/courtcase/V2000__add_hearing_defendant_newoffence_table.sql
@@ -1,0 +1,47 @@
+DROP TABLE IF EXISTS DEFENDANT_OFFENCE;
+DROP TABLE IF EXISTS DEFENDANT;
+DROP TABLE IF EXISTS HEARING;
+
+CREATE TABLE HEARING (
+	ID                  SERIAL       PRIMARY KEY,
+	COURT_CASE_ID       INT8         NOT NULL,
+    SESSION_START_TIME  TIMESTAMP    NOT NULL,
+    COURT_CODE          TEXT         NOT NULL,
+    COURT_ROOM          TEXT         NOT NULL,
+    LIST_NO             TEXT         NOT NULL,
+    CREATED             TIMESTAMP    NOT NULL DEFAULT now(),
+    CREATED_BY          TEXT         NULL,
+    CONSTRAINT fk_hearing_court_case FOREIGN KEY (COURT_CASE_ID) REFERENCES COURT_CASE (ID)
+);
+
+CREATE TABLE DEFENDANT (
+    ID                  SERIAL      PRIMARY KEY,
+    COURT_CASE_ID       INT8        NOT NULL,
+    DEFENDANT_NAME      TEXT        NOT NULL,
+    TYPE                TEXT        NOT NULL DEFAULT 'PERSON',
+    NAME                JSONB       NOT NULL,
+    ADDRESS             JSONB       NULL,
+    CRN                 TEXT        NULL,
+    PNC                 TEXT        NULL,
+    CRO                 TEXT        NULL,
+    DATE_OF_BIRTH       DATE        NULL,
+    SEX                 TEXT        NULL,
+    NATIONALITY_1       TEXT        NULL,
+    NATIONALITY_2       TEXT        NULL,
+    CREATED             TIMESTAMP   NOT NULL DEFAULT now(),
+    CREATED_BY          TEXT        NULL,
+    CONSTRAINT fk_defendant_court_case FOREIGN KEY (COURT_CASE_ID) REFERENCES COURT_CASE (ID)
+);
+
+-- Expect that this table will be renamed to OFFENCE when the existing OFFENCE is retired and dropped
+CREATE TABLE DEFENDANT_OFFENCE (
+    ID              SERIAL      PRIMARY KEY,
+    DEFENDANT_ID    INT8        NOT NULL,
+    SUMMARY         TEXT        NOT NULL,
+    TITLE           TEXT        NOT NULL,
+    SEQUENCE        INT4        NOT NULL,
+    ACT             TEXT        NULL,
+    CREATED         TIMESTAMP   NOT NULL DEFAULT now(),
+    CREATED_BY      TEXT        NULL,
+    CONSTRAINT fk_defendant_offence_defendant FOREIGN KEY (DEFENDANT_ID) REFERENCES DEFENDANT (ID)
+);

--- a/src/main/resources/db/migration/courtcase/V2000__add_hearing_defendant_newoffence_table.sql
+++ b/src/main/resources/db/migration/courtcase/V2000__add_hearing_defendant_newoffence_table.sql
@@ -5,7 +5,8 @@ DROP TABLE IF EXISTS HEARING;
 CREATE TABLE HEARING (
 	ID                  SERIAL       PRIMARY KEY,
 	COURT_CASE_ID       INT8         NOT NULL,
-    SESSION_START_TIME  TIMESTAMP    NOT NULL,
+    HEARING_DAY         DATE         NOT NULL,
+    HEARING_TIME        TIME         NOT NULL,
     COURT_CODE          TEXT         NOT NULL,
     COURT_ROOM          TEXT         NOT NULL,
     LIST_NO             TEXT         NOT NULL,

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -174,3 +174,13 @@ VALUES (16000, '16000','B10JQ');
 
 INSERT INTO courtcaseservicetest.offender_match(CONFIRMED, REJECTED, CRN, CRO, MATCH_TYPE, PNC, GROUP_ID)
 VALUES (false, false, 'X980123', 'CRO1', 'NAME_DOB', 'A/160000BA', 16000);
+
+
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, session_start_time, list_no)
+VALUES (1, 1700028913, 'B10JQ', 1, '2019-12-14 09:00', '1st');
+
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
+VALUES (1, 1700028913, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
+
+INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
+VALUES (1, 1, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -176,8 +176,8 @@ INSERT INTO courtcaseservicetest.offender_match(CONFIRMED, REJECTED, CRN, CRO, M
 VALUES (false, false, 'X980123', 'CRO1', 'NAME_DOB', 'A/160000BA', 16000);
 
 
-INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, session_start_time, list_no)
-VALUES (1, 1700028913, 'B10JQ', 1, '2019-12-14 09:00', '1st');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (1, 1700028913, 'B10JQ', 1, '2019-12-14', '09:00', '1st');
 
 INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
 VALUES (1, 1700028913, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');


### PR DESCRIPTION
Have also added some sample data. I tested the fetching of linked collections by debugging existing tests but didn't want to add methods to our services which would enable full integration tests.

As mentioned in a comment, the CourtCaseEntity cannot have 3 collections annotated with EAGER. We will need to look at this when we start fetching in our services but it looks like the Hibernate annotation LazyCollection could be a solution. We may need to start considering what should be lazy or not, and adjusting the session boundaries.

I haven't done it here but I think we should probably adopt a hearingDay field in the HEARING entity because we usually search on the hearing date (with no time) and it would give a more performant query.