### PR TITLE
🐞 PIC-1609 create new endpoint controller for getCases (extended)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.time.LocalDate
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.3'
+    id 'org.springframework.boot' version '2.5.4'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'com.github.ben-manes.versions' version '0.39.0'
     id "org.flywaydb.flyway" version "7.14.0"

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseCaseIdController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseCaseIdController.java
@@ -1,0 +1,109 @@
+package uk.gov.justice.probation.courtcaseservice.controller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.AllArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.justice.probation.courtcaseservice.controller.mapper.CourtCaseResponseMapper;
+import uk.gov.justice.probation.courtcaseservice.controller.model.CaseListResponse;
+import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseResponse;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.service.CourtCaseService;
+import uk.gov.justice.probation.courtcaseservice.service.OffenderMatchService;
+
+import static java.time.LocalTime.MIDNIGHT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Api(tags = "Court and Cases Resources")
+@RestController
+@AllArgsConstructor
+public class CourtCaseCaseIdController {
+
+    // See https://www.postgresql.org/docs/9.0/datatype-datetime.html
+    private static final int MAX_YEAR_SUPPORTED_BY_DB = 294276;
+    private static final int MAX_AGE = 1;
+    private static final LocalDateTime NEVER_MODIFIED_DATE = LocalDateTime.of(2020, MAX_AGE, MAX_AGE, 0, 0);
+    private final CourtCaseService courtCaseService;
+    private final OffenderMatchService offenderMatchService;
+
+    @ApiOperation(value = "Gets case data for a court on a date. ",
+            notes = "Response is sorted by court room, session start time and by defendant surname. The createdAfter and " +
+                    "createdBefore filters will not filter out updates originating from prepare-a-case, these manual updates" +
+                    " are always assumed to be correct as they have been deliberately made by authorised users rather than " +
+                    "automated systems.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(code = 200, message = "OK", response = CaseListResponse.class),
+                    @ApiResponse(code = 304, message = "Not modified"),
+                    @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+                    @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+                    @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+                    @ApiResponse(code = 404, message = "If the court is not found by the code passed."),
+                    @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+            })
+    @GetMapping(value = "/court/{courtCode}/cases/extended", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<CaseListResponse> getCaseList(
+            @PathVariable String courtCode,
+            @RequestParam(value = "date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "createdAfter", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdAfter,
+            @RequestParam(value = "createdBefore", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdBefore,
+            WebRequest webRequest
+    ) {
+        var lastModified = courtCaseService.findLastModifiedByHearingDay(courtCode, date)
+            .orElse(NEVER_MODIFIED_DATE)
+            .toInstant(ZoneOffset.UTC);
+        if (webRequest.checkNotModified(lastModified.toEpochMilli())) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED)
+                    .cacheControl(CacheControl.maxAge(MAX_AGE, TimeUnit.SECONDS))
+                    .build();
+        }
+
+        final var createdAfterOrDefault = Optional.ofNullable(createdAfter)
+                .orElse(
+                        LocalDateTime.of(date, MIDNIGHT).minusDays(8)
+                );
+
+        final var createdBeforeOrDefault = Optional.ofNullable(createdBefore)
+                .orElse(LocalDateTime.of(MAX_YEAR_SUPPORTED_BY_DB, 12, 31, 23, 59));
+
+        final var courtCaseEntities = courtCaseService.filterCasesByHearingDay(courtCode, date, createdAfterOrDefault, createdBeforeOrDefault);
+        final var courtCases = courtCaseEntities.stream()
+                .sorted(Comparator.comparing(CourtCaseEntity::getCourtRoom)
+                        .thenComparing(CourtCaseEntity::getSessionStartTime)
+                        .thenComparing(CourtCaseEntity::getDefendantSurname))
+                .map(this::buildCourtCaseResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok()
+                .lastModified(lastModified)
+                .cacheControl(CacheControl.maxAge(MAX_AGE, TimeUnit.SECONDS))
+                .body(CaseListResponse.builder().cases(courtCases).build());
+    }
+
+    private CourtCaseResponse buildCourtCaseResponse(CourtCaseEntity courtCaseEntity) {
+        final var offenderMatchesCount = offenderMatchService.getMatchCount(courtCaseEntity.getCourtCode(), courtCaseEntity.getCaseNo())
+                .orElse(0);
+
+        return CourtCaseResponseMapper.mapFrom(courtCaseEntity, offenderMatchesCount);
+    }
+}

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CourtCaseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -69,12 +70,44 @@ public interface CourtCaseRepository extends CrudRepository<CourtCaseEntity, Lon
             LocalDateTime createdBefore
     );
 
+    @Query(value = "select cc.*, grouped_cases.min_created as first_created " +
+        "from court_case cc " +
+        "   inner join " +
+        "       (select min(group_cc.created) as min_created, max(group_cc.created) as max_created, group_cc.case_id from court_case group_cc " +
+        "           inner join hearing on hearing.court_case_id = group_cc.id  " +
+        "           where ((group_cc.created >= :createdAfter and group_cc.created < :createdBefore) " +
+        "             or (group_cc.created >= :createdBefore and group_cc.manual_update is true)) " +
+        "           and hearing.court_code = :courtCode " +
+        "           group by group_cc.case_id) grouped_cases " +
+        "       on cc.case_id = grouped_cases.case_id " +
+        "   inner join hearing h on h.court_case_id = cc.id " +
+        "where h.hearing_day = :hearingDay " +
+        "and cc.created = grouped_cases.max_created " +
+        "and cc.deleted = false",
+        nativeQuery = true)
+    List<CourtCaseEntity> findByCourtCodeAndHearingDay(
+        String courtCode,
+        LocalDate hearingDay,
+        LocalDateTime createdAfter,
+        LocalDateTime createdBefore
+    );
+
+
     @Query(value = "select cc.created " +
             "from court_case cc where court_code=:courtCode " +
             "   and (session_start_time between :sessionStartTimeStart and :sessionStartTimeEnd) " +
             "order by created desc limit 1",
             nativeQuery = true)
     Optional<LocalDateTime> findLastModified(String courtCode, LocalDateTime sessionStartTimeStart, LocalDateTime sessionStartTimeEnd);
+
+    @Query(value = "select cc.created " +
+        "from court_case cc " +
+        "inner join hearing h on h.court_case_id = cc.id " +
+        "where h.court_code = :courtCode " +
+        "and h.hearing_day = :hearingDay " +
+        "order by created desc limit 1",
+        nativeQuery = true)
+    Optional<LocalDateTime> findLastModifiedByHearingDay(String courtCode, LocalDate hearingDay);
 
     @Query(value = "select cc.*, grouped_cases.min_created as first_created from court_case cc "
             + "inner join (select min(created) as min_created, max(created) as max_created, case_no, court_code from court_case group_cc "

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
@@ -21,5 +21,9 @@ public interface CourtCaseService {
 
     List<CourtCaseEntity> filterCases(String courtCode, LocalDate date, LocalDateTime createdAfter, LocalDateTime createdBefore);
 
+    List<CourtCaseEntity> filterCasesByHearingDay(String courtCode, LocalDate hearingDay, LocalDateTime createdAfter, LocalDateTime createdBefore);
+
     Optional<LocalDateTime> filterCasesLastModified(String courtCode, LocalDate date);
+
+    Optional<LocalDateTime> findLastModifiedByHearingDay(String courtCode, LocalDate date);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseService.java
@@ -131,6 +131,14 @@ public class ImmutableCourtCaseService implements CourtCaseService {
         return courtCaseRepository.findByCourtCodeAndSessionStartTime(court.getCourtCode(), start, start.plusDays(1), createdAfter, createdBefore);
     }
 
+    @Override
+    public List<CourtCaseEntity> filterCasesByHearingDay(String courtCode, LocalDate hearingDay, LocalDateTime createdAfter, LocalDateTime createdBefore) {
+        final var court = courtRepository.findByCourtCode(courtCode)
+            .orElseThrow(() -> new EntityNotFoundException("Court %s not found", courtCode));
+
+        return courtCaseRepository.findByCourtCodeAndHearingDay(court.getCourtCode(), hearingDay, createdAfter, createdBefore);
+    }
+
     private void validateEntity(String caseId, CourtCaseEntity updatedCase) {
         checkCourtExists(updatedCase.getCourtCode());
         checkEntityCaseIdAgree(caseId, updatedCase);
@@ -192,5 +200,9 @@ public class ImmutableCourtCaseService implements CourtCaseService {
     public Optional<LocalDateTime> filterCasesLastModified(String courtCode, LocalDate searchDate) {
         final var start = LocalDateTime.of(searchDate, LocalTime.MIDNIGHT);
         return courtCaseRepository.findLastModified(courtCode, start, start.plusDays(1));
+    }
+
+    public Optional<LocalDateTime> findLastModifiedByHearingDay(String courtCode, LocalDate searchDate) {
+        return courtCaseRepository.findLastModifiedByHearingDay(courtCode, searchDate);
     }
 }

--- a/src/main/resources/db/migration/courtcase/V2004__add_fk_hearing_court.sql
+++ b/src/main/resources/db/migration/courtcase/V2004__add_fk_hearing_court.sql
@@ -1,0 +1,6 @@
+BEGIN;
+    ALTER TABLE HEARING ADD CONSTRAINT fk_hearing_court
+                    FOREIGN KEY (court_code)
+                    REFERENCES court (court_code);
+    ALTER TABLE COURT_CASE DROP CONSTRAINT fk_court_case_court;
+COMMIT;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.jdbc.Sql;
@@ -27,6 +28,7 @@ import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.get
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
 public class CourtCaseControllerIntTest extends BaseIntTest {
+
     public static final String KEY_ID = "mock-key";
     private static final String LAST_MODIFIED_COURT_CODE = "B14LO";
 
@@ -40,13 +42,16 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
     private static final String PROBATION_STATUS = "Possible NDelius record";
     private static final String NOT_FOUND_COURT_CODE = "LPL";
 
-    @Test
-    void GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases() {
+    @Nested
+    class GetCasesCaseNo {
 
-        given()
+        @Test
+        void GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases() {
+
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/{courtCode}/cases?date={date}", COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
                 .then()
                 .assertThat()
@@ -54,7 +59,7 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("cases", hasSize(6))
                 .body("cases[0].courtCode", equalTo(COURT_CODE))
                 .body("cases[0].caseNo", equalTo("1600028914"))
-                .body("cases[0].caseId", equalTo("5555556"))
+                .body("cases[0].caseId", equalTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a56"))
                 .body("cases[0].defendantType", equalTo("PERSON"))
                 .body("cases[0].sessionStartTime", equalTo(LocalDateTime.of(2019, 12, 14, 0, 0).format(DateTimeFormatter.ISO_DATE_TIME)))
                 .body("cases[0].createdToday", equalTo(true))
@@ -77,48 +82,49 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("cases[4].probationStatusActual", equalTo("NO_RECORD"))
                 .body("cases[5].caseNo", equalTo("1600028918"))
                 .body("cases[5].createdToday", equalTo(false));
-    }
+        }
 
-    @Test
-    void givenLastModifiedRecent_whenRequestCases_thenReturnLastModifiedHeader() {
+        @Test
+        void givenLastModifiedRecent_whenRequestCases_thenReturnLastModifiedHeader() {
 
-        given()
-            .auth()
-            .oauth2(getToken())
-            .when()
-            .get("/court/{courtCode}/cases?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
-            .then()
-            .assertThat()
-            .statusCode(200)
-            .header("Last-Modified", equalTo("Tue, 01 Jun 2021 16:59:59 GMT"))
-            .header("Cache-Control", equalTo("max-age=1"))
-            ;
-    }
-
-    @Test
-    void givenNoDataChange_whenGetCases_thenReturn304() {
-
-        given()
-            .auth()
-            .oauth2(getToken())
-            .header(HttpHeaders.IF_UNMODIFIED_SINCE, "Tue, 04 Feb 1970 19:57:25 GMT")
-            .when()
-            .get("/court/{courtCode}/cases?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
-            .then()
-            .assertThat()
-            .statusCode(304)
-            .header("Cache-Control", equalTo("max-age=1"))
-        ;
-    }
-
-    @Test
-    void GET_cases_givenCreatedAfterFilterParam_whenGetCases_thenReturnCasesAfterSpecifiedTime() {
-
-        given()
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
-                .get("/court/{courtCode}/cases?date={date}&createdAfter=2020-10-01T16:59:58.999", COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                .when()
+                .get("/court/{courtCode}/cases?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .header("Last-Modified", equalTo("Tue, 01 Jun 2021 16:59:59 GMT"))
+                .header("Cache-Control", equalTo("max-age=1"))
+            ;
+        }
+
+        @Test
+        void givenNoDataChange_whenGetCases_thenReturn304() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .header(HttpHeaders.IF_UNMODIFIED_SINCE, "Tue, 04 Feb 1970 19:57:25 GMT")
+                .when()
+                .get("/court/{courtCode}/cases?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(304)
+                .header("Cache-Control", equalTo("max-age=1"))
+            ;
+        }
+
+        @Test
+        void GET_cases_givenCreatedAfterFilterParam_whenGetCases_thenReturnCasesAfterSpecifiedTime() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/{courtCode}/cases?date={date}&createdAfter=2020-10-01T16:59:58.999", COURT_CODE,
+                    LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
                 .then()
                 .assertThat()
                 .statusCode(200)
@@ -128,92 +134,92 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("cases[2].caseNo", equalTo("1600028917"))
                 .body("cases[3].caseNo", equalTo("1600028915"))
                 .body("cases[4].caseNo", equalTo("1600028918"))
-        ;
-    }
+            ;
+        }
 
-    @Test
-    void GET_cases_givenCreatedBeforeFilterParam_whenGetCases_thenReturnCasesCreatedUpTo8DaysBeforeListDate() {
-        given()
+        @Test
+        void GET_cases_givenCreatedBeforeFilterParam_whenGetCases_thenReturnCasesCreatedUpTo8DaysBeforeListDate() {
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
-                .get("/court/{courtCode}/cases?date={date}&createdBefore=2020-10-05T00:00:00", COURT_CODE, LocalDate.of(2020, 5, 01).format(DateTimeFormatter.ISO_DATE))
+                .when()
+                .get("/court/{courtCode}/cases?date={date}&createdBefore=2020-10-05T00:00:00", COURT_CODE,
+                    LocalDate.of(2020, 5, 01).format(DateTimeFormatter.ISO_DATE))
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .body("cases", hasSize(1))
                 .body("cases[0].caseNo", equalTo("1600028930"))
-        ;
-    }
+            ;
+        }
 
-    @Test
-    void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_whenGetCases_thenReturnCasesBetweenSpecifiedTimes() {
+        @Test
+        void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_whenGetCases_thenReturnCasesBetweenSpecifiedTimes() {
 
-        given()
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/{courtCode}/cases?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00",
-                        COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                    COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .body("cases", hasSize(1))
                 .body("cases[0].caseNo", equalTo("1600028916"))
-        ;
-    }
+            ;
+        }
 
-    @Test
-    void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates() {
+        @Test
+        void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates() {
 
-        given()
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/B30NY/cases?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00",
-                        LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                    LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .body("cases", hasSize(1))
                 .body("cases[0].caseNo", equalTo("1600028919"))
                 .body("cases[0].defendantName", equalTo("Hubert Farnsworth"))
-        ;
-    }
+            ;
+        }
 
-    @Test
-    void GET_cases_shouldGetEmptyCaseListWhenNoCasesMatch() {
-        given()
+        @Test
+        void GET_cases_shouldGetEmptyCaseListWhenNoCasesMatch() {
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/{courtCode}/cases?date={date}", COURT_CODE, "2020-02-02")
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .body("cases", empty());
+        }
 
-    }
-
-    @Test
-    void GET_cases_shouldReturn400BadRequestWhenNoDateProvided() {
-        given()
+        @Test
+        void GET_cases_shouldReturn400BadRequestWhenNoDateProvided() {
+            given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/{courtCode}/cases", COURT_CODE)
                 .then()
                 .assertThat()
                 .statusCode(400)
                 .body("developerMessage", equalTo("Required request parameter 'date' for method parameter type LocalDate is not present"));
-    }
+        }
 
-    @Test
-    void GET_cases_shouldReturn404NotFoundWhenCourtDoesNotExist() {
-        ErrorResponse result = given()
+        @Test
+        void GET_cases_shouldReturn404NotFoundWhenCourtDoesNotExist() {
+            ErrorResponse result = given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .get("/court/{courtCode}/cases?date={date}", NOT_FOUND_COURT_CODE, "2020-02-02")
                 .then()
                 .assertThat()
@@ -222,34 +228,38 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body()
                 .as(ErrorResponse.class);
 
-        assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
-        assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
-        assertThat(result.getStatus()).isEqualTo(404);
+            assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getStatus()).isEqualTo(404);
+        }
     }
 
-    @Test
-    void shouldGetCaseWhenCourtExists() {
-        given()
+    @Nested
+    class GetCaseByCourtAndCaseNo {
+
+        @Test
+        void shouldGetCaseWhenCourtExists() {
+            given()
                 .given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .header("Accept", "application/json")
                 .get("/court/{courtCode}/case/{caseNo}", COURT_CODE, CASE_NO)
                 .then()
                 .assertThat().statusCode(200);
-    }
+        }
 
-    @Test
-    void shouldGetCaseWhenExists() {
+        @Test
+        void shouldGetCaseWhenExists() {
 
-        String startTime = LocalDateTime.of(2019, Month.DECEMBER, 14, 9, 0, 0)
+            String startTime = LocalDateTime.of(2019, Month.DECEMBER, 14, 9, 0, 0)
                 .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        given()
+            given()
                 .given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .header("Accept", "application/json")
                 .get("/court/{courtCode}/case/{caseNo}", COURT_CODE, CASE_NO)
                 .then()
@@ -291,20 +301,20 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("removed", equalTo(false))
                 .body("createdToday", equalTo(true))
                 .body("numberOfPossibleMatches", equalTo(3))
-        ;
-    }
+            ;
+        }
 
 
-    @Test
-    void shouldReturnNotFoundForNonexistentCase() {
+        @Test
+        void shouldReturnNotFoundForNonexistentCase() {
 
-        String NOT_FOUND_CASE_NO = "11111111111";
+            String NOT_FOUND_CASE_NO = "11111111111";
 
-        ErrorResponse result = given()
+            ErrorResponse result = given()
                 .given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .header("Accept", "application/json")
                 .get("/court/{courtCode}/case/{caseNo}", COURT_CODE, NOT_FOUND_CASE_NO)
                 .then()
@@ -313,22 +323,22 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body()
                 .as(ErrorResponse.class);
 
-        assertThat(result.getDeveloperMessage()).contains("Case " + NOT_FOUND_CASE_NO + " not found");
-        assertThat(result.getUserMessage()).contains("Case " + NOT_FOUND_CASE_NO + " not found");
-        assertThat(result.getStatus()).isEqualTo(404);
-    }
+            assertThat(result.getDeveloperMessage()).contains("Case " + NOT_FOUND_CASE_NO + " not found");
+            assertThat(result.getUserMessage()).contains("Case " + NOT_FOUND_CASE_NO + " not found");
+            assertThat(result.getStatus()).isEqualTo(404);
+        }
 
 
-    @Test
-    void shouldReturnNotFoundForDeletedCase() {
+        @Test
+        void shouldReturnNotFoundForDeletedCase() {
 
-        String DELETED_CASE_NO = "1600128918";
+            String DELETED_CASE_NO = "1600128918";
 
-        ErrorResponse result = given()
+            ErrorResponse result = given()
                 .given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .header("Accept", "application/json")
                 .get("/court/{courtCode}/case/{caseNo}", COURT_CODE, DELETED_CASE_NO)
                 .then()
@@ -337,18 +347,18 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body()
                 .as(ErrorResponse.class);
 
-        assertThat(result.getDeveloperMessage()).contains("Case " + DELETED_CASE_NO + " not found");
-        assertThat(result.getUserMessage()).contains("Case " + DELETED_CASE_NO + " not found");
-        assertThat(result.getStatus()).isEqualTo(404);
-    }
+            assertThat(result.getDeveloperMessage()).contains("Case " + DELETED_CASE_NO + " not found");
+            assertThat(result.getUserMessage()).contains("Case " + DELETED_CASE_NO + " not found");
+            assertThat(result.getStatus()).isEqualTo(404);
+        }
 
-    @Test
-    void shouldReturnNotFoundForNonexistentCourt() {
-        ErrorResponse result = given()
+        @Test
+        void shouldReturnNotFoundForNonexistentCourt() {
+            ErrorResponse result = given()
                 .given()
                 .auth()
                 .oauth2(getToken())
-        .when()
+                .when()
                 .header("Accept", "application/json")
                 .get("/court/{courtCode}/case/{caseNo}", NOT_FOUND_COURT_CODE, CASE_NO)
                 .then()
@@ -357,9 +367,210 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body()
                 .as(ErrorResponse.class);
 
-        assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
-        assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
-        assertThat(result.getStatus()).isEqualTo(404);
+            assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getStatus()).isEqualTo(404);
+        }
+    }
+
+
+    @Nested
+    class GetCasesExtended {
+
+        private static final String BASE_PATH_WITH_DATE = "/court/%s/cases/extended?date=%s";
+        private static final String BASE_PATH = "/court/%s/cases/extended";
+
+        @Test
+        void GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases() {
+
+            final var path = String.format(BASE_PATH_WITH_DATE, COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE));
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get(path)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", hasSize(6))
+                .body("cases[0].courtCode", equalTo(COURT_CODE))
+                .body("cases[0].caseNo", equalTo("1600028914"))
+                .body("cases[0].caseId", equalTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a56"))
+                .body("cases[0].defendantType", equalTo("PERSON"))
+                .body("cases[0].sessionStartTime", equalTo(LocalDateTime.of(2019, 12, 14, 0, 0).format(DateTimeFormatter.ISO_DATE_TIME)))
+                .body("cases[0].createdToday", equalTo(true))
+                .body("cases[0].probationStatus", equalTo("Pre-sentence record"))
+                .body("cases[0].probationStatusActual", equalTo("NOT_SENTENCED"))
+                .body("cases[1].offences", hasSize(2))
+                .body("cases[1].caseNo", equalTo("1600028913"))
+                .body("cases[1].preSentenceActivity", equalTo(true))
+                .body("cases[1].probationStatus", equalTo("Possible NDelius record"))
+                .body("cases[1].probationStatusActual", equalTo(null))
+                .body("cases[1].offences[0].sequenceNumber", equalTo(1))
+                .body("cases[1].offences[1].sequenceNumber", equalTo(2))
+                .body("cases[1].numberOfPossibleMatches", equalTo(3))
+                .body("cases[1].sessionStartTime", equalTo(LocalDateTime.of(2019, 12, 14, 9, 0).format(DateTimeFormatter.ISO_DATE_TIME)))
+                .body("cases[1].awaitingPsr", equalTo(true))
+                .body("cases[3].caseNo", equalTo("1600028916"))
+                .body("cases[4].caseNo", equalTo("1600028915"))
+                .body("cases[4].sessionStartTime", equalTo(LocalDateTime.of(2019, 12, 14, 23, 59, 59).format(DateTimeFormatter.ISO_DATE_TIME)))
+                .body("cases[4].probationStatus", equalTo("No record"))
+                .body("cases[4].probationStatusActual", equalTo("NO_RECORD"))
+                .body("cases[5].caseNo", equalTo("1600028918"))
+                .body("cases[5].createdToday", equalTo(false));
+        }
+
+        @Test
+        void givenLastModifiedRecent_whenRequestCases_thenReturnLastModifiedHeader() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/{courtCode}/cases/extended?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .header("Last-Modified", equalTo("Tue, 01 Jun 2021 16:59:59 GMT"))
+                .header("Cache-Control", equalTo("max-age=1"))
+            ;
+        }
+
+        @Test
+        void givenNoDataChange_whenGetCases_thenReturn304() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .header(HttpHeaders.IF_UNMODIFIED_SINCE, "Tue, 04 Feb 1970 19:57:25 GMT")
+                .when()
+                .get("/court/{courtCode}/cases/extended?date={date}", LAST_MODIFIED_COURT_CODE, LocalDate.of(2021, 6, 1).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(304)
+                .header("Cache-Control", equalTo("max-age=1"))
+            ;
+        }
+
+        @Test
+        void GET_cases_givenCreatedAfterFilterParam_whenGetCases_thenReturnCasesAfterSpecifiedTime() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/{courtCode}/cases/extended?date={date}&createdAfter=2020-10-01T16:59:58.999", COURT_CODE,
+                    LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", hasSize(5))
+                .body("cases[0].caseNo", equalTo("1600028914"))
+                .body("cases[1].caseNo", equalTo("1600028913"))
+                .body("cases[2].caseNo", equalTo("1600028917"))
+                .body("cases[3].caseNo", equalTo("1600028915"))
+                .body("cases[4].caseNo", equalTo("1600028918"))
+            ;
+        }
+
+        @Test
+        void GET_cases_givenCreatedBeforeFilterParam_whenGetCases_thenReturnCasesCreatedUpTo8DaysBeforeListDate() {
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/{courtCode}/cases/extended?date={date}&createdBefore=2020-10-05T00:00:00", COURT_CODE,
+                    LocalDate.of(2020, 5, 01).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", hasSize(1))
+                .body("cases[0].caseNo", equalTo("1600028930"))
+            ;
+        }
+
+        @Test
+        void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_whenGetCases_thenReturnCasesBetweenSpecifiedTimes() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/{courtCode}/cases/extended?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00",
+                    COURT_CODE, LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", hasSize(1))
+                .body("cases[0].caseNo", equalTo("1600028916"))
+            ;
+        }
+
+        @Test
+        void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates() {
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get("/court/B30NY/cases/extended?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00",
+                    LocalDate.of(2019, 12, 14).format(DateTimeFormatter.ISO_DATE))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", hasSize(1))
+                .body("cases[0].caseNo", equalTo("1600028919"))
+                .body("cases[0].defendantName", equalTo("Hubert Farnsworth"))
+            ;
+        }
+
+        @Test
+        void GET_cases_shouldGetEmptyCaseListWhenNoCasesMatch() {
+            final var path = String.format(BASE_PATH_WITH_DATE, COURT_CODE, "2020-02-02");
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get(path)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("cases", empty());
+        }
+
+        @Test
+        void GET_cases_shouldReturn400BadRequestWhenNoDateProvided() {
+            final var path = String.format(BASE_PATH, COURT_CODE);
+            given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get(path)
+                .then()
+                .assertThat()
+                .statusCode(400)
+                .body("developerMessage", equalTo("Required request parameter 'date' for method parameter type LocalDate is not present"));
+        }
+
+        @Test
+        void GET_cases_shouldReturn404NotFoundWhenCourtDoesNotExist() {
+            final var path = String.format(BASE_PATH_WITH_DATE, NOT_FOUND_COURT_CODE, "2020-02-02");
+            ErrorResponse result = given()
+                .auth()
+                .oauth2(getToken())
+                .when()
+                .get(path)
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .body()
+                .as(ErrorResponse.class);
+
+            assertThat(result.getDeveloperMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getUserMessage()).contains("Court " + NOT_FOUND_COURT_CODE + " not found");
+            assertThat(result.getStatus()).isEqualTo(404);
+        }
     }
 
 }

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -10,62 +10,107 @@ INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('Leicester', '
 INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('Aberystwyth', 'B63AD');
 INSERT INTO courtcaseservicetest.court (name, court_code) VALUES ('New New York', 'B30NY');
 
-INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created, awaiting_psr) VALUES (1700028913, 5555555, 1600028913, 'B10JQ', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now(), true);
+-- START DEFINITION OF CASE NO 1700028913
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created, awaiting_psr) VALUES (-1700028900, '1f93aa0a-7e46-4885-a1cb-f25a4be33a00', 1600028913, 'B10JQ', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now(), true);
 
--- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnCasesForToday()
+INSERT INTO courtcaseservicetest.OFFENCE (COURT_CASE_ID, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER)
+VALUES (-1700028900, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+INSERT INTO courtcaseservicetest.OFFENCE (COURT_CASE_ID, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER)
+VALUES (-1700028900, 'Theft from a different shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 2);
+
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1000000, -1700028900, 'B10JQ', 1, '2019-12-14', '09:00', '3rd');
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
+VALUES (-1000000, -1700028900, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
+INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
+VALUES (-1000000, -1000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
+VALUES (-1000001, -1000000, 'Theft from a different shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 2);
+-- END DEFINITION OF 1700028913
+
+-- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
 -- These records are used to test edge cases when returning court case list for a given date (midnight to 1 second before midnight the next day)
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555556, 1600028914, 'B10JQ', 1,
-'2019-12-14 00:00', 'NOT_SENTENCED', 'X320742','Mr Billy ZANE', now());
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555557, 1600028915, 'B10JQ', 1,
-'2019-12-14 23:59:59', 'NO_RECORD', 'X320743', 'Mr Nicholas CAGE', now());
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028901, '1f93aa0a-7e46-4885-a1cb-f25a4be33a56', 1600028914, 'B10JQ', 1, '2019-12-14 00:00', 'NOT_SENTENCED', 'X320742','Mr Billy ZANE', now());
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028901, -1700028901, 'B10JQ', 1, '2019-12-14', '00:00', '3rd');
+
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028902, '1f93aa0a-7e46-4885-a1cb-f25a4be33a57', 1600028915, 'B10JQ', 1, '2019-12-14 23:59:59', 'NO_RECORD', 'X320743', 'Mr Nicholas CAGE', now());
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028902, -1700028902, 'B10JQ', 1, '2019-12-14', '23:59:59', '3rd');
 
 -- See CourtCaseControllerIntTest.GET_cases_givenCreatedAfterFilterParam_whenGetCases_thenReturnCasesAfterSpecifiedTime()
 -- These records are used to test the createdAfter filters
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555558, 1600028916, 'B10JQ', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320744', 'Mr Mads Mikkelsen',
-'2020-09-01 16:59:59');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'CURRENT', 'X320745', 'Mr Hideo Kojima',
-'2020-10-01 16:59:59');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'NO_RECORD', 'X320745', 'Mr Hideo Kojima',
-'2020-10-01 18:59:59');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028903, '1f93aa0a-7e46-4885-a1cb-f25a4be33a58', 1600028916, 'B10JQ', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320744', 'Mr Mads Mikkelsen', '2020-09-01 16:59:59');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028903, -1700028903, 'B10JQ', 1, '2019-12-14', '12:59:59', '3rd');
+
+-- 2 versions for case id '1f93aa0a-7e46-4885-a1cb-f25a4be33a58'
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028904, '1f93aa0a-7e46-4885-a1cb-f25a4be33a59', 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'CURRENT', 'X320745', 'Mr Hideo Kojima', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028904, -1700028904, 'B10JQ', 1, '2019-12-14', '12:59:59', '3rd');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028905, '1f93aa0a-7e46-4885-a1cb-f25a4be33a59', 1600028917, 'B10JQ', 1,'2019-12-14 12:59:59', 'NO_RECORD', 'X320745', 'Mr Hideo Kojima', '2020-10-01 18:59:59');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028905, -1700028905, 'B10JQ', 1, '2019-12-14', '12:59:59', '3rd');
 
 -- See GET_cases_givenCreatedBeforeFilterParam_whenGetCases_thenReturnCasesCreatedUpTo8DaysBeforeListDate
 -- Used to test default createdBefore date
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028930, 'B10JQ', 1,'2020-05-01 12:59:59', 'NO_RECORD', 'X320745', 'Mr Hideo Kojima',
-'2020-05-01 18:59:59');
-
-
-
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, created_by, manual_update) VALUES (5555560, 1600028919, 'B30NY', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320654', 'Hubert Farnsworth',
-'2020-10-01 16:59:59', 'TURANGALEE(prepare-a-case-for-court)', true);
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028906, '1f93aa0a-7e46-4885-a1cb-f25a4be33a30', 1600028930, 'B10JQ', 1,'2020-05-01 12:59:59', 'NO_RECORD', 'X320745', 'Mr Hideo Kojima', '2020-05-01 18:59:59');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-1700028906, -1700028906, 'B10JQ', 1, '2020-05-01', '12:59:59', '3rd');
 
 -- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
 -- These records are used to test that the createdToday field returns false if a new record was created today updating an existing one
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie',
-'2020-10-01 16:59:59');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created) VALUES (5555559, 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie',
-now());
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028907, '1f93aa0a-7e46-4885-a1cb-f25a4be33a18', 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028907, -1700028907, 'B10JQ', 2, '2019-12-14', '13:00:00', '3rd', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+VALUES (-1700028908, '1f93aa0a-7e46-4885-a1cb-f25a4be33a18', 1600028918, 'B10JQ', 2,'2019-12-14 13:00:00', 'NO_RECORD', 'X320746', 'Mr David Bowie', now());
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028908, -1700028908, 'B10JQ', 2, '2019-12-14', '13:00:00', '3rd', now());
 
+-- See GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, created_by, manual_update)
+VALUES (-1700028909, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600028919, 'B30NY', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320654', 'Hubert Farnsworth', '2020-10-01 16:59:59', 'TURANGALEE(prepare-a-case-for-court)', true);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028909, -1700028909, 'B30NY', 1, '2019-12-14', '12:59:59', '3rd', '2020-10-01 16:59:59');
+
+-- CHECKED - tests pass without
 -- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
 -- These cases simulate when a case has been moved to a future date, in this case it should no longer appear in the old case list
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
-VALUES (5555557, 1600028921, 'B10JQ', 1,'2020-02-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-15 00:00:00');
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
-VALUES (5555557, 1600028921, 'B10JQ', 1,'2019-12-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-14 00:00:00');
+-- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+-- VALUES (5555557, 1600028921, 'B10JQ', 1,'2020-02-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-15 00:00:00');
+-- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
+-- VALUES (5555557, 1600028921, 'B10JQ', 1,'2019-12-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-14 00:00:00');
 
+-- CHECKED - tests pass without
 -- These records are used to test soft deletion
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted) VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
-'2020-10-01 16:59:59', false);
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted) VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
-now(), true);
+-- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
+-- VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59', false);
+-- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
+-- VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie', now(), true);
 
--- These records are used to test the Last-Modified header
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted) VALUES (5555559, 1600128919, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
-'2020-10-01 16:59:59', false);
-INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted) VALUES (5555559, 1600128920, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie',
-'2021-06-01 16:59:59', false);
+-- These records are used to test the Last-Modified header CHECKED
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
+VALUES (-1700028910, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600128919, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59', false);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028910, -1700028910, 'B14LO', 1, '2021-06-01', '13:00:00', '3rd', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
+VALUES (-1700028911, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600128919, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59', false);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028911, -1700028911, 'B14LO', 2, '2021-06-01', '13:00:00', '3rd', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
+VALUES (-1700028912, '1f93aa0a-7e46-4885-a1cb-f25a4be33a20', 1600128920, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2021-06-01 16:59:59', false);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700028912, -1700028912, 'B14LO', 2, '2021-06-01', '13:00:00', '3rd', '2021-06-01 16:59:59');
 
-
--- See CourtCaseControllerPutIntTest.whenPurgeCases_ThenReturn204NoContent()
+-- See CourtCaseControllerPutIntTest.whenPurgeCases_ThenReturn204NoContent() CHECKED
 -- These records are used to test edge cases when returning court case list for a given date (midnight to 1 second before midnight the next day)
 INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
 VALUES (1000000, 1000000, 1000000, 'B10JQ', '1', '2100-01-01 09:00:00', 'No record', 'X320741');
@@ -89,28 +134,6 @@ INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, c
 VALUES (1000008, 1000008, 1000008, 'B10JQ', '1', '2020-01-03 09:00:00', 'No record', 'X320741');
 INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn)
 VALUES (1000009, 1000009, 1000009, 'B10JQ', '1', '2020-01-03 09:00:00', 'No record', 'X320741');
-
-INSERT INTO courtcaseservicetest.OFFENCE (COURT_CASE_ID,
-                                          OFFENCE_TITLE,
-                                          OFFENCE_SUMMARY,
-                                          ACT,
-                                          SEQUENCE_NUMBER)
-VALUES (1700028913,
-        'Theft from a shop',
-        'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.',
-        'Contrary to section 1(1) and 7 of the Theft Act 1968.',
-        1);
-
-INSERT INTO courtcaseservicetest.OFFENCE (COURT_CASE_ID,
-                                          OFFENCE_TITLE,
-                                          OFFENCE_SUMMARY,
-                                          ACT,
-                                          SEQUENCE_NUMBER)
-VALUES (1700028913,
-        'Theft from a different shop',
-        'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.',
-        'Contrary to section 1(1) and 7 of the Theft Act 1968.',
-        2);
 
 INSERT INTO courtcaseservicetest.OFFENCE (ID, COURT_CASE_ID, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER)
 VALUES (1000001, 1000001, 'Title', 'Summary.', 'ACT.', 1);
@@ -178,19 +201,20 @@ VALUES (false, false, 'X980123', 'CRO1', 'NAME_DOB', 'A/160000BA', 16000);
 --
 -- Section to populate an entirely new COURT CASE with separate HEARING, DEFENDANT, DEFENDANT_OFFENCE. Also a caseId which looks like a UUID which is what will be happening post CP integration
 INSERT INTO courtcaseservicetest.COURT_CASE (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created, awaiting_psr)
-VALUES (1700030000, 'ac24a1be-939b-49a4-a524-21a3d228f8bc', '1700030000', 'B14LO', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now(), true);
+VALUES (-1700030000, 'ac24a1be-939b-49a4-a524-21a3d2230000', '1700030000', 'B14LO', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now() - interval '2 hours', true);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700030000, -1700030000, 'B14LO', 1, '2019-12-14', '09:00:00', '3rd', now() - interval '2 hours');
 
 INSERT INTO courtcaseservicetest.COURT_CASE (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created, awaiting_psr)
-VALUES (1700030001, 'ac24a1be-939b-49a4-a524-21a3d228f8bc', '1700030000', 'B14LO', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now(), true);
+VALUES (-1700030001, 'ac24a1be-939b-49a4-a524-21a3d2230000', '1700030000', 'B14LO', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}','{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', null, 'A/1234560BA', '311462/13E', '3rd', '1958-10-10', 'M', 'British', 'Polish' , now(), true);
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
+VALUES (-1700030001, -1700030001, 'B14LO', 1, '2019-12-14', '09:00', '3rd', now());
 
 INSERT INTO courtcaseservicetest.OFFENCE (ID, COURT_CASE_ID, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER)
-VALUES (17000, 1700030001, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
-
-INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
-VALUES (1000000, 1700030001, 'B10JQ', 1, '2019-12-14', '09:00', '1st');
+VALUES (-17000, -1700030001, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
 
 INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
-VALUES (1000000, 1700030001, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
+VALUES (-2000000, -1700030001, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
 
 INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
-VALUES (1000000, 1000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+VALUES (-2000000, -2000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -81,21 +81,6 @@ VALUES (-1700028909, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600028919, 'B30NY'
 INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
 VALUES (-1700028909, -1700028909, 'B30NY', 1, '2019-12-14', '12:59:59', '3rd', '2020-10-01 16:59:59');
 
--- CHECKED - tests pass without
--- See CourtCaseControllerIntTest.GET_cases_givenNoCreatedFilterParams_whenGetCases_thenReturnAllCases()
--- These cases simulate when a case has been moved to a future date, in this case it should no longer appear in the old case list
--- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
--- VALUES (5555557, 1600028921, 'B10JQ', 1,'2020-02-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-15 00:00:00');
--- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created)
--- VALUES (5555557, 1600028921, 'B10JQ', 1,'2019-12-14 13:00:00', 'No record', 'X320743', 'Mr Future', '2019-11-14 00:00:00');
-
--- CHECKED - tests pass without
--- These records are used to test soft deletion
--- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
--- VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59', false);
--- INSERT INTO courtcaseservicetest.court_case (case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
--- VALUES (5555559, 1600128918, 'B10JQ', 2,'2019-12-14 13:00:00', 'No record', 'X320746', 'Mr David Bowie', now(), true);
-
 -- These records are used to test the Last-Modified header CHECKED
 INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted)
 VALUES (-1700028910, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600128919, 'B14LO', 2,'2021-06-01 13:00:00', 'No record', 'X320746', 'Mr David Bowie', '2020-10-01 16:59:59', false);


### PR DESCRIPTION
The  intent of the ticket was to remove the FK relationship from court_case to court and add it to court_case to hearing. This is done in the ticket. Also changed was the queries related to the endpoint /court/{court}/cases. As discussed, so as to enable more easy performance testing later, I have added new queries and a new controller at a new endpoint at /court/{court}/cases/extended. There is a new @Nested set of test classes in the CourtCaseControllerIntTest for this new endpoint. These test cases are exactly the same as the ones for the old get cases endpoint, save for the path.

The biggest part of the work was refactoring and adjustment of the before-test.sql. I had to add hearing records for most of the cases, as well as controlling the (usually generated) id fields for court_case. Most of these are now negative which I think makes analysis easier. I have added some look-up in a spreadsheet here. https://docs.google.com/spreadsheets/d/1o1wcn8AAMbCS84CRZ6tIcfb8DiuWMTNh1SOPc6Fje_o/edit#gid=0

Also, replaced the case_id values with UUIDs and made them unique where they should be,

Also, removed some unused SQL from the before-test.sql.