### PR TITLE
✨ PIC-1640 added a UUID to Defendant entity

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
@@ -4,6 +4,7 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseRespo
 import uk.gov.justice.probation.courtcaseservice.controller.model.OffenceResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.ProbationStatus;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenceEntity;
 
 import java.time.LocalDate;
@@ -40,12 +41,21 @@ public class CourtCaseResponseMapper {
             .defendantDob(courtCaseEntity.getDefendantDob())
             .defendantSex(courtCaseEntity.getDefendantSex())
             .defendantType(courtCaseEntity.getDefendantType())
+            .defendantUuid(getDefendantUuid(courtCaseEntity.getDefendants()))
             .nationality1(courtCaseEntity.getNationality1())
             .nationality2(courtCaseEntity.getNationality2())
             .createdToday(LocalDate.now().isEqual(Optional.ofNullable(courtCaseEntity.getFirstCreated()).orElse(LocalDateTime.now()).toLocalDate()))
             .numberOfPossibleMatches(matchCount)
             .awaitingPsr(courtCaseEntity.getAwaitingPsr())
             .build();
+    }
+
+    static String getDefendantUuid(List<DefendantEntity> defendantEntities) {
+        return Optional.ofNullable(defendantEntities).orElse(Collections.emptyList())
+            .stream()
+            .findFirst()
+            .map(DefendantEntity::getUuid)
+            .orElse(null);
     }
 
     private static List<OffenceResponse> mapOffencesFrom(CourtCaseEntity courtCaseEntity) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseRequest.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,6 +45,7 @@ public class CourtCaseRequest {
     private final LocalDate defendantDob;
     private final String defendantSex;
     private final DefendantType defendantType;
+    private final String defendantUuid;
     private final String crn;
     private final String pnc;
     private final String cro;
@@ -153,6 +155,7 @@ public class CourtCaseRequest {
             .nationality2(nationality2)
             .name(name)
             .sex(defendantSex)
+            .uuid(Optional.ofNullable(defendantUuid).orElse(UUID.randomUUID().toString()))
             .crn(crn)
             .cro(cro)
             .pnc(pnc)

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseResponse.java
@@ -50,6 +50,7 @@ public class CourtCaseResponse {
     private final LocalDate defendantDob;
     private final String defendantSex;
     private final DefendantType defendantType;
+    private final String defendantUuid;
     private final String nationality1;
     private final String nationality2;
     private final boolean createdToday;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/Defendant.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/Defendant.java
@@ -16,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @AllArgsConstructor
 public class Defendant {
+    private final String uuid;
     private final NamePropertiesEntity name;
     private final LocalDate dateOfBirth;
     private final AddressRequest address;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequest.java
@@ -77,6 +77,7 @@ public class ExtendedCourtCaseRequest {
             .sex(defendant.getSex())
             .suspendedSentenceOrder(defendant.getSuspendedSentenceOrder())
             .type(defendant.getType())
+            .uuid(defendant.getUuid())
             .build();
         offences.forEach(offence -> offence.setDefendant(defendantEntity));
         return defendantEntity;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
@@ -83,6 +83,7 @@ public class CourtCaseEntity extends BaseImmutableEntity implements Serializable
     @Column(name = "PRE_SENTENCE_ACTIVITY", nullable = false)
     private final Boolean preSentenceActivity;
 
+    @ToString.Exclude
     @JsonManagedReference
     @OneToMany(mappedBy = "courtCase", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval=true)
     private final List<OffenceEntity> offences;
@@ -90,11 +91,14 @@ public class CourtCaseEntity extends BaseImmutableEntity implements Serializable
     // If you have more than one collection with fetch = FetchType.EAGER then there is an exception
     // org.hibernate.loader.MultipleBagFetchException: cannot simultaneously fetch multiple bags
     // After CP integration, we will need to look at session boundaries @LazyCollection is one solution
+    @ToString.Exclude
     @LazyCollection(value = LazyCollectionOption.FALSE)
     @JsonIgnore
     @OneToMany(mappedBy = "courtCase", cascade = CascadeType.ALL, orphanRemoval=true)
     private final List<HearingEntity> hearings;
 
+    @ToString.Exclude
+    @LazyCollection(value = LazyCollectionOption.FALSE)
     @JsonIgnore
     @OneToMany(mappedBy = "courtCase", cascade = CascadeType.ALL, orphanRemoval=true)
     private final List<DefendantEntity> defendants;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.ToString.Exclude;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Type;
 
@@ -32,7 +33,7 @@ import org.hibernate.annotations.Type;
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @SuperBuilder
 @Getter
-@ToString(exclude = "courtCase")
+@ToString
 @EqualsAndHashCode(callSuper = true, exclude = "courtCase")
 public class DefendantEntity extends BaseImmutableEntity implements Serializable {
 
@@ -42,11 +43,16 @@ public class DefendantEntity extends BaseImmutableEntity implements Serializable
     @JsonIgnore
     private final Long id;
 
+    @ToString.Exclude
     @ManyToOne(optional = false)
     @JoinColumn(name = "COURT_CASE_ID", referencedColumnName = "id", nullable = false)
     @Setter
     private CourtCaseEntity courtCase;
 
+    @Column(name = "UUID", nullable = false)
+    private final String uuid;
+
+    @ToString.Exclude
     @OneToMany(mappedBy = "defendant", cascade = CascadeType.ALL, orphanRemoval=true)
     private final List<DefendantOffenceEntity> offences;
 

--- a/src/main/resources/db/migration/courtcase/V2005__add_defendant_uuid.sql
+++ b/src/main/resources/db/migration/courtcase/V2005__add_defendant_uuid.sql
@@ -1,0 +1,7 @@
+BEGIN;
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    alter table DEFENDANT add column UUID UUID not null;
+
+    -- uuid_generate_v1 is based on MAC address of computer, timestamp and a random number, v4 on 3 random numbers
+    update DEFENDANT SET UUID = uuid_generate_v4() where UUID is null;
+COMMIT;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.COURT_CODE;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_UUID;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
@@ -283,6 +284,7 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("courtCode", equalTo(COURT_CODE))
                 .body("sessionStartTime", equalTo(startTime))
                 .body("defendantName", equalTo("Mr Johnny BALL"))
+                .body("defendantUuid", equalTo("40db17d6-04db-11ec-b2d8-0242ac130002"))
                 .body("name.title", equalTo("Mr"))
                 .body("name.forename1", equalTo("Johnny"))
                 .body("name.forename2", equalTo("John"))
@@ -303,7 +305,6 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
                 .body("numberOfPossibleMatches", equalTo(3))
             ;
         }
-
 
         @Test
         void shouldReturnNotFoundForNonexistentCase() {
@@ -327,7 +328,6 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
             assertThat(result.getUserMessage()).contains("Case " + NOT_FOUND_CASE_NO + " not found");
             assertThat(result.getStatus()).isEqualTo(404);
         }
-
 
         @Test
         void shouldReturnNotFoundForDeletedCase() {
@@ -372,7 +372,6 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
             assertThat(result.getStatus()).isEqualTo(404);
         }
     }
-
 
     @Nested
     class GetCasesExtended {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
@@ -123,11 +124,11 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
                 .body("listNo", equalTo(LIST_NO))
                 .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
                 .body("defendantSex", equalTo(DEFENDANT_SEX))
+                .body("defendantUuid", notNullValue())
                 .body("nationality1", equalTo(NATIONALITY_1))
                 .body("nationality2", equalTo(NATIONALITY_2))
                 .body("awaitingPsr", equalTo(true))
             ;
-
         }
 
         @Test
@@ -154,6 +155,7 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
                 .body("listNo", equalTo(LIST_NO))
                 .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
                 .body("defendantSex", equalTo(DEFENDANT_SEX))
+                .body("defendantUuid", notNullValue())
                 .body("nationality1", equalTo(NATIONALITY_1))
                 .body("nationality2", equalTo(NATIONALITY_2))
                 .body("courtRoom", equalTo("2"))

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
@@ -6,6 +6,7 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.ProbationStatu
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtSession;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantType;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.GroupedOffenderMatchesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.NamePropertiesEntity;
@@ -42,6 +43,7 @@ class CourtCaseResponseMapperTest {
     private static final String ACT = "ACT";
     private static final String DEFENDANT_NAME = "DEFENDANT_NAME";
     private static final DefendantType DEFENDANT_TYPE = DefendantType.PERSON;
+    private static final String DEFENDANT_UUID = "81cdaec1-d197-4a70-b2a8-beeabdd05d21";
     private static final String CRN = "CRN";
     private static final String PNC = "PNC";
     private static final String CRO = "CRO";
@@ -54,6 +56,7 @@ class CourtCaseResponseMapperTest {
     private static final LocalDateTime FIRST_CREATED = LocalDateTime.of(2020, 1, 1, 1, 1);
     private CourtCaseEntity courtCaseEntity;
     private List<OffenceEntity> offences;
+    private List<DefendantEntity> defendants;
     private final AddressPropertiesEntity addressPropertiesEntity = AddressPropertiesEntity.builder()
         .line1("27")
         .line2("Elm Place")
@@ -74,8 +77,18 @@ class CourtCaseResponseMapperTest {
             OffenceEntity.builder().offenceTitle(OFFENCE_TITLE).offenceSummary(OFFENCE_SUMMARY).act(ACT).sequenceNumber(1).build(),
             OffenceEntity.builder().offenceTitle(OFFENCE_TITLE + "2").offenceSummary(OFFENCE_SUMMARY + "2").act(ACT + "2").sequenceNumber(2).build()
         );
+        defendants = Arrays.asList(
+            DefendantEntity.builder().defendantName(DEFENDANT_NAME)
+                .name(namePropertiesEntity)
+                .sex(DEFENDANT_SEX)
+                .nationality1(NATIONALITY_1)
+                .nationality2(NATIONALITY_2)
+                .dateOfBirth(DEFENDANT_DOB)
+                .pnc(PNC)
+                .uuid(DEFENDANT_UUID).build()
+        );
         matchGroups = buildMatchGroups();
-        courtCaseEntity = buildCourtCaseEntity(offences, FIRST_CREATED);
+        courtCaseEntity = buildCourtCaseEntity(offences, defendants, FIRST_CREATED);
     }
 
     @Test
@@ -93,6 +106,7 @@ class CourtCaseResponseMapperTest {
         assertThat(courtCaseResponse.getPreSentenceActivity()).isEqualTo(PRE_SENTENCE_ACTIVITY);
         assertThat(courtCaseResponse.getDefendantName()).isEqualTo(DEFENDANT_NAME);
         assertThat(courtCaseResponse.getDefendantType()).isEqualTo(DEFENDANT_TYPE);
+        assertThat(courtCaseResponse.getDefendantUuid()).isEqualTo(DEFENDANT_UUID);
         assertThat(courtCaseResponse.getDefendantAddress()).isEqualTo(addressPropertiesEntity);
         assertThat(courtCaseResponse.getName()).isEqualTo(namePropertiesEntity);
         assertThat(courtCaseResponse.getSessionStartTime()).isEqualTo(SESSION_START_TIME);
@@ -112,7 +126,7 @@ class CourtCaseResponseMapperTest {
 
     @Test
     void shouldSetCreatedTodayToTrueIfCreatedToday() {
-        var courtCaseResponse = CourtCaseResponseMapper.mapFrom(buildCourtCaseEntity(offences, LocalDateTime.now()), 1);
+        var courtCaseResponse = CourtCaseResponseMapper.mapFrom(buildCourtCaseEntity(offences, defendants, LocalDateTime.now()), 1);
         assertThat(courtCaseResponse.isCreatedToday()).isTrue();
     }
 
@@ -143,7 +157,7 @@ class CourtCaseResponseMapperTest {
             .collect(Collectors.toList());
         Collections.reverse(reorderedOffences);
 
-        var reorderedCourtCaseEntity = buildCourtCaseEntity(reorderedOffences, FIRST_CREATED);
+        var reorderedCourtCaseEntity = buildCourtCaseEntity(reorderedOffences, defendants, FIRST_CREATED);
 
         var courtCaseResponse = CourtCaseResponseMapper.mapFrom(reorderedCourtCaseEntity, 1);
 
@@ -152,7 +166,12 @@ class CourtCaseResponseMapperTest {
 
         var secondOffence = courtCaseResponse.getOffences().get(1);
         assertThat(secondOffence.getOffenceTitle()).isEqualTo(OFFENCE_TITLE + "2");
+    }
 
+    @Test
+    void whenNoDefendants_thenGetFirstUuid() {
+        var uuid = CourtCaseResponseMapper.getDefendantUuid(null);
+        assertThat(uuid).isNull();
     }
 
     private GroupedOffenderMatchesEntity buildMatchGroups() {
@@ -168,7 +187,7 @@ class CourtCaseResponseMapperTest {
                         .build();
     }
 
-    private CourtCaseEntity buildCourtCaseEntity(List<OffenceEntity> offences, LocalDateTime firstCreated) {
+    private CourtCaseEntity buildCourtCaseEntity(List<OffenceEntity> offences, List<DefendantEntity> defendants, LocalDateTime firstCreated) {
         return CourtCaseEntity.builder()
             .id(ID)
             .pnc(PNC)
@@ -196,6 +215,7 @@ class CourtCaseResponseMapperTest {
             .created(CREATED)
             .offences(offences)
             .firstCreated(firstCreated)
+            .defendants(defendants)
             .awaitingPsr(true)
             .build();
     }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseRequestTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/CourtCaseRequestTest.java
@@ -18,6 +18,7 @@ import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_DOB;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_NAME;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_SEX;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_UUID;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NAME;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_1;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_2;
@@ -50,6 +51,7 @@ class CourtCaseRequestTest {
                                                                 )
                                                             )
                                                             .defendantDob(DEFENDANT_DOB)
+                                                            .defendantUuid(DEFENDANT_UUID)
                                                             .name(NAME)
                                                             .defendantName(NAME.getFullName())
                                                             .defendantAddress(new AddressRequest("LINE1", "LINE2", "LINE3", "LINE4", "LINE5", "POSTCODE"))
@@ -167,5 +169,9 @@ class CourtCaseRequestTest {
         assertThat(entity.getProbationStatus()).isEqualTo("PROBATION_STATUS");
 
         assertThat(entity.getHearings()).hasSize(1);
+        assertThat(entity.getDefendants()).hasSize(1);
+        assertThat(entity.getDefendants().get(0).getUuid()).isNotNull();
+        assertThat(entity.getDefendants().get(0).getDefendantName()).isEqualTo(DEFENDANT_NAME);
+        assertThat(entity.getDefendants().get(0).getDateOfBirth()).isEqualTo(DEFENDANT_DOB);
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequestTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequestTest.java
@@ -15,6 +15,7 @@ import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CRN;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CRO;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_DOB;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_UUID;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.LIST_NO;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NAME;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.PNC;
@@ -84,6 +85,7 @@ class ExtendedCourtCaseRequestTest {
             .sex("M")
             .suspendedSentenceOrder(Boolean.TRUE)
             .type(DefendantType.PERSON)
+            .uuid(DEFENDANT_UUID)
             .offences(List.of(OffenceRequest.builder()
                                 .offenceTitle("TITLE1")
                                 .offenceSummary("SUMMARY1")
@@ -144,6 +146,7 @@ class ExtendedCourtCaseRequestTest {
         assertThat(defendantEntity.getPreviouslyKnownTerminationDate()).isEqualTo(LocalDate.of(2021, Month.MARCH, 20));
         assertThat(defendantEntity.getProbationStatus()).isEqualTo("CURRENT");
         assertThat(defendantEntity.getSex()).isEqualTo("M");
+        assertThat(defendantEntity.getUuid()).isEqualTo(DEFENDANT_UUID);
 
         final var offences = defendantEntity.getOffences();
         assertThat(offences).hasSize(2);

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
@@ -28,6 +28,7 @@ public class EntityHelper {
     public static final String DEFENDANT_NAME = NAME.getFullName();
     public static final AddressPropertiesEntity DEFENDANT_ADDRESS = new AddressPropertiesEntity("27", "Elm Place", "AB21 3ES", "Bangor", null, null);
     public static final LocalDate DEFENDANT_DOB = LocalDate.of(1958, 12, 14);
+    public static final String DEFENDANT_UUID = "d1eefed2-04df-11ec-b2d8-0242ac130002";
     public static final String PNC = "PNC";
     public static final String CRO = "CRO/12334";
     public static final String DEFENDANT_SEX = "M";
@@ -86,6 +87,7 @@ public class EntityHelper {
             .sex(DEFENDANT_SEX)
             .nationality1(NATIONALITY_1)
             .nationality2(NATIONALITY_2)
+            .uuid(DEFENDANT_UUID)
             .awaitingPsr(AWAITING_PSR)
             .breach(BREACH)
             .preSentenceActivity(PRE_SENTENCE_ACTIVITY)

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -20,8 +20,8 @@ VALUES (-1700028900, 'Theft from a different shop', 'On 01/01/2015 at own, stole
 
 INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
 VALUES (-1000000, -1700028900, 'B10JQ', 1, '2019-12-14', '09:00', '3rd');
-INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
-VALUES (-1000000, -1700028900, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, uuid, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
+VALUES (-1000000, -1700028900, '40db17d6-04db-11ec-b2d8-0242ac130002', 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
 INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
 VALUES (-1000000, -1000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
 INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
@@ -198,8 +198,8 @@ VALUES (-1700030001, -1700030001, 'B14LO', 1, '2019-12-14', '09:00', '3rd', now(
 INSERT INTO courtcaseservicetest.OFFENCE (ID, COURT_CASE_ID, OFFENCE_TITLE, OFFENCE_SUMMARY, ACT, SEQUENCE_NUMBER)
 VALUES (-17000, -1700030001, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
 
-INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
-VALUES (-2000000, -1700030001, 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, uuid, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2)
+VALUES (-2000000, -1700030001, 'd49323c0-04da-11ec-b2d8-0242ac130002', 'Mr Johnny BALL', '{"title": "Mr", "surname": "BALL", "forename1": "Johnny", "forename2": "John", "forename3": "Jon"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', null, 'A/1234560BA', '311462/13E', 'M', 'British', 'Polish');
 
 INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
 VALUES (-2000000, -2000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);

--- a/src/test/resources/integration/request/PUT_courtCaseExtended_success.json
+++ b/src/test/resources/integration/request/PUT_courtCaseExtended_success.json
@@ -31,6 +31,7 @@
       "crn": "X320741",
       "pnc": "A/1234560BA",
       "cro": "99999",
+      "uuid": "d1eefed2-04df-11ec-b2d8-0242ac130002",
       "previouslyKnownTerminationDate": "2018-06-24",
       "suspendedSentenceOrder": true,
       "breach": true,


### PR DESCRIPTION
Adds a UUID to the defendant. This has been done so that we have a natural key to link the offender matches to. It is expected that CCM will always send a value for the CP data. For the Libra feed, one should be generated in CCM and sent or else it will be generated in CCS.