### PR TITLE
✨ PIC-1619 - save offender match group by defendant and case id

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,13 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-ORACLE7-KRB5LIBS-1303151:
+  SNYK-JAVA-IONETTY-1584064:
     - '*':
-        reason: Kerberos not used. We will move to Java 16 base image
-        expires: 2021-06-30T00:00:00.000Z
+        reason: Third party version (netty-codec) with version out of our control, comes via spring boot
+        expires: 2021-09-21T00:00:00.000Z
+  SNYK-JAVA-IONETTY-1584063:
+    - '*':
+        reason: Third party library (netty-codec) with version out of our control, comes via spring boot
+        expires: 2021-09-21T00:00:00.000Z
 patch: {}
 version: v1.13.5

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesController.java
@@ -52,6 +52,27 @@ public class OffenderMatchesController {
                     .build());
     }
 
+    @ApiOperation(value = "Creates a new offender-match entity associated with a case and a defendant ID")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "OK", response = GroupedOffenderMatchesEntity.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not Found, if for example, the court code does not exist.", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @PostMapping(value = "/case/{caseId}/defendant/{defendantId}/grouped-offender-matches", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public @ResponseBody
+    Mono<ResponseEntity<Object>> createGroupedOffenderMatchesByDefendant(@PathVariable(value = "caseId") String caseId,
+        @PathVariable(value = "defendantId") String defendantId,
+        @Valid @RequestBody GroupedOffenderMatchesRequest request) {
+        return offenderMatchService.createOrUpdateGroupedMatchesByDefendant(caseId, defendantId, request)
+            .map(match -> ResponseEntity.created(URI.create(String.format("/case/%s/defendant/%s/grouped-offender-matches/%s", caseId, defendantId, match.getId())))
+                .build());
+    }
+
     @ApiOperation(value = "Gets an existing offender-match entity associated with a case")
     @ApiResponses(
             value = {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesController.java
@@ -92,6 +92,25 @@ public class OffenderMatchesController {
          return offenderMatchService.getGroupedMatches(courtCode, caseNo, groupId);
     }
 
+    @ApiOperation(value = "Gets an existing offender-match entity associated with a case")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "OK", response = GroupedOffenderMatchesEntity.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not Found, if for example, the court code does not exist.", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @GetMapping(value = "/case/{caseId}/defendant/{defendantId}/grouped-offender-matches/{groupId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    public @ResponseBody
+    Mono<GroupedOffenderMatchesEntity> getOffenderMatchesByCaseId(@PathVariable(value = "caseId") String caseId,
+        @PathVariable(value = "defendantId") String defendantId,
+        @PathVariable(value = "groupId") Long groupId) {
+        return offenderMatchService.getGroupedMatchesByCaseId(caseId, defendantId, groupId);
+    }
+
     @ApiOperation(value = "Returns all possible matches found for a given case")
     @ApiResponses(
         value = {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/GroupedOffenderMatchesEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/GroupedOffenderMatchesEntity.java
@@ -42,11 +42,21 @@ public class GroupedOffenderMatchesEntity extends BaseEntity implements Serializ
     @OrderBy("crn ASC")
     private List<OffenderMatchEntity> offenderMatches;
 
+    @Deprecated
     @Column(name = "CASE_NO")
     private String caseNo;
 
+    @Deprecated
     @Column(name = "COURT_CODE")
     private String courtCode;
+
+    @Setter
+    @Column(name = "CASE_ID")
+    private String caseId;
+
+    @Setter
+    @Column(name = "DEFENDANT_ID")
+    private String defendantId;
 
     public void clearOffenderMatches() {
         if (this.offenderMatches != null) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/GroupedOffenderMatchRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/GroupedOffenderMatchRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 public interface GroupedOffenderMatchRepository extends CrudRepository<GroupedOffenderMatchesEntity, Long> {
     Optional<GroupedOffenderMatchesEntity> findByCourtCodeAndCaseNo(String courtCode, String caseNo);
 
+    Optional<GroupedOffenderMatchesEntity> findByCaseId(String caseId);
+
     @Query(value = "select count(om.id) from offender_match om "
         + "INNER join offender_match_group omg "
         + "on omg.id = om.group_id "

--- a/src/main/resources/db/migration/courtcase/V2008__offender_match_defendant_and_case_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2008__offender_match_defendant_and_case_id.sql
@@ -1,0 +1,30 @@
+BEGIN;
+    ALTER TABLE OFFENDER_MATCH_GROUP ADD COLUMN CASE_ID TEXT;
+    ALTER TABLE OFFENDER_MATCH_GROUP ADD COLUMN DEFENDANT_ID TEXT;
+
+    -- Migrate existing records in offender_match_group so that they have case and defendant id
+    UPDATE offender_match_group omg
+    SET    case_id = t2.new_case_id ,
+           defendant_id = t2.defendant_id
+    FROM   offender_match_group  omg_from
+    JOIN
+        (
+            select cc.case_no , cc.court_code , cc.case_id as new_case_id, defendant_id from court_case cc
+            inner join
+            (
+                select max(group_cc.created) as max_created, group_cc.case_id, defendant.defendant_id from court_case group_cc
+                INNER JOIN defendant ON (defendant.court_case_id = group_cc.id)
+                group by case_id, defendant.defendant_id
+            ) grouped_cases
+            on cc.case_id = grouped_cases.case_id
+            where cc.created = grouped_cases.max_created
+            and cc.deleted = false
+        ) t2
+    ON t2.court_code = omg_from.court_code AND t2.case_no = omg_from.case_no
+    WHERE  omg.case_no = omg_from.case_no
+    and omg.court_code = omg_from.court_code;
+
+    -- There should be a unique key on case id and defendant id as there was for court code and case no
+    CREATE UNIQUE INDEX offender_match_group_uq1 ON OFFENDER_MATCH_GROUP (CASE_ID, DEFENDANT_ID);
+    ALTER TABLE OFFENDER_MATCH_GROUP ADD CONSTRAINT offender_match_group_uq1 UNIQUE USING INDEX offender_match_group_uq1;
+COMMIT;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/OffenderMatchesControllerIntTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
@@ -16,6 +17,7 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 import static uk.gov.justice.probation.courtcaseservice.controller.OffenderMatchesControllerTest.OFFENDER_MATCHES_DETAIL_PATH;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CASE_NO;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.COURT_CODE;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
@@ -23,22 +25,20 @@ import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.get
 @Sql(scripts = "classpath:after-test.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
 class OffenderMatchesControllerIntTest extends BaseIntTest {
 
-    private static final String CASE_NO = "1600028913";
-
     public static final String SINGLE_EXACT_MATCH_BODY = "{\n" +
-            "    \"matches\": [\n" +
-            "        {\n" +
-            "                \"matchIdentifiers\": {\n" +
-            "                \"crn\": \"X346204\",\n" +
-            "                \"pnc\": \"pnc123\",\n" +
-            "                \"cro\": \"cro456\"\n" +
-            "            },\n" +
-            "            \"matchType\": \"NAME_DOB\",\n" +
-            "            \"confirmed\": \"true\",\n" +
-            "            \"rejected\": \"false\"\n" +
-            "        }\n" +
-            "    ]\n" +
-            "}";
+        "    \"matches\": [\n" +
+        "        {\n" +
+        "                \"matchIdentifiers\": {\n" +
+        "                \"crn\": \"X346204\",\n" +
+        "                \"pnc\": \"pnc123\",\n" +
+        "                \"cro\": \"cro456\"\n" +
+        "            },\n" +
+        "            \"matchType\": \"NAME_DOB\",\n" +
+        "            \"confirmed\": \"true\",\n" +
+        "            \"rejected\": \"false\"\n" +
+        "        }\n" +
+        "    ]\n" +
+        "}";
 
     public static final String MULTIPLE_NON_EXACT_MATCH_BODY =  "{\n" +
         "    \"matches\": [\n" +
@@ -61,30 +61,33 @@ class OffenderMatchesControllerIntTest extends BaseIntTest {
         "    ]\n" +
         "}";
 
-    @Test
-    void givenCaseExists_whenPostMadeToOffenderMatches_thenReturn201CreatedWithValidLocation() {
-        String location = given()
+    @Nested
+    class PostMatchRequestCourtCodeAndCaseNo {
+
+        @Test
+        void givenCaseExists_whenPostMadeToOffenderMatches_thenReturn201CreatedWithValidLocation() {
+            String location = given()
                 .auth()
                 .oauth2(getToken())
                 .accept(APPLICATION_JSON_VALUE)
                 .contentType(APPLICATION_JSON_VALUE)
                 .body(SINGLE_EXACT_MATCH_BODY)
-            .when()
+                .when()
                 .post("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches")
-            .then()
+                .then()
                 .statusCode(201)
                 .header("Location", matchesPattern("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches/[0-9]+"))
                 .extract()
                 .header("Location");
 
-        given()
+            given()
                 .auth()
                 .oauth2(getToken())
                 .accept(APPLICATION_JSON_VALUE)
                 .contentType(APPLICATION_JSON_VALUE)
-            .when()
+                .when()
                 .get(location)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("courtCode", equalTo(COURT_CODE))
                 .body("caseNo", equalTo("1600028913"))
@@ -92,161 +95,271 @@ class OffenderMatchesControllerIntTest extends BaseIntTest {
                 .body("offenderMatches[0].crn", equalTo("X346204"))
                 .body("offenderMatches[0].pnc", equalTo("pnc123"))
                 .body("offenderMatches[0].cro", equalTo("cro456"))
-                .body("offenderMatches[0].matchType",  equalTo("NAME_DOB"))
+                .body("offenderMatches[0].matchType", equalTo("NAME_DOB"))
                 .body("offenderMatches[0].confirmed", equalTo(true));
-    }
+        }
 
-    @Test
-    void givenNewCase_whenPostMadeToOffenderMatchesWithMultipleMatches_thenReturn201CreatedWithValidLocation() {
+        @Test
+        void givenNewCase_whenPostMadeToOffenderMatchesWithMultipleMatches_thenReturn201CreatedWithValidLocation() {
 
-        String location = given()
-            .auth()
-            .oauth2(getToken())
-            .accept(APPLICATION_JSON_VALUE)
-            .contentType(APPLICATION_JSON_VALUE)
-            .body(MULTIPLE_NON_EXACT_MATCH_BODY)
-            .when()
-            .post("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches")
-            .then()
-            .statusCode(201)
-            .header("Location", matchesPattern("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches/[0-9]+"))
-            .extract()
-            .header("Location");
-
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(APPLICATION_JSON_VALUE)
-            .contentType(APPLICATION_JSON_VALUE)
-            .when()
-            .get(location)
-            .then()
-            .statusCode(200)
-            .body("courtCode", equalTo(COURT_CODE))
-            .body("caseNo", equalTo("1600028913"))
-            .body("offenderMatches", hasSize(2))
-            .body("offenderMatches[0].crn", equalTo("X12345"))
-            .body("offenderMatches[0].pnc", equalTo(null))
-            .body("offenderMatches[0].cro", equalTo(null))
-            .body("offenderMatches[0].matchType",  equalTo("PARTIAL_NAME"))
-            .body("offenderMatches[0].confirmed", equalTo(false))
-            .body("offenderMatches[0].rejected", equalTo(false))
-            .body("offenderMatches[1].matchType",  equalTo("NAME_DOB_ALIAS"))
-        ;
-    }
-
-    @Test
-    void givenCourtDoesNotExist_whenPostMadeToOffenderMatches_thenReturnNotFound() {
-        given()
+            String location = given()
                 .auth()
                 .oauth2(getToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .accept(APPLICATION_JSON_VALUE)
                 .contentType(APPLICATION_JSON_VALUE)
-                .body(SINGLE_EXACT_MATCH_BODY)
-            .when()
-                .post("/court/FOO/case/1234567890/grouped-offender-matches")
-            .then()
-                .statusCode(404)
-                    .body("userMessage", equalTo("Court FOO not found"))
-                    .body("developerMessage" , equalTo("Court FOO not found"));
-    }
+                .body(MULTIPLE_NON_EXACT_MATCH_BODY)
+                .when()
+                .post("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches")
+                .then()
+                .statusCode(201)
+                .header("Location", matchesPattern("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches/[0-9]+"))
+                .extract()
+                .header("Location");
 
-    @Test
-    void givenCaseDoesNotExist_whenPostMadeToOffenderMatches_thenReturnNotFound() {
-        given()
+            given()
                 .auth()
                 .oauth2(getToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .accept(APPLICATION_JSON_VALUE)
                 .contentType(APPLICATION_JSON_VALUE)
-                .body(SINGLE_EXACT_MATCH_BODY)
-            .when()
-                .post("/court/" + COURT_CODE + "/case/1234567890/grouped-offender-matches")
-            .then()
-                .statusCode(404)
-                    .body("userMessage", equalTo("Case 1234567890 not found for court " + COURT_CODE))
-                    .body("developerMessage" , equalTo("Case 1234567890 not found for court " + COURT_CODE));
-    }
-
-    @Test
-    void givenMultipleMatchesOneNotFound_whenGetOffenderDetailMatch_thenReturn200() {
-
-        String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, CASE_NO);
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(APPLICATION_JSON_VALUE)
-            .contentType(APPLICATION_JSON_VALUE)
-            .when()
-            .get(path)
-            .then()
-            .statusCode(200)
-            .body("offenderMatchDetails", hasSize(1))
-            .body("offenderMatchDetails[0].title", equalTo("Mr."))
-            .body("offenderMatchDetails[0].forename", equalTo("Aadland"))
-            .body("offenderMatchDetails[0].middleNames", hasSize(2))
-            .body("offenderMatchDetails[0].middleNames[0]", equalTo("Felix"))
-            .body("offenderMatchDetails[0].middleNames[1]", equalTo("Hope"))
-            .body("offenderMatchDetails[0].surname", equalTo("Bertrand"))
-            .body("offenderMatchDetails[0].dateOfBirth", equalTo("2000-07-19"))
-            .body("offenderMatchDetails[0].address.addressNumber", equalTo("19"))
-            .body("offenderMatchDetails[0].address.streetName", equalTo("Junction Road"))
-            .body("offenderMatchDetails[0].address.district", equalTo("Blackheath"))
-            .body("offenderMatchDetails[0].address.town", equalTo("Sheffield"))
-            .body("offenderMatchDetails[0].address.county", equalTo("South Yorkshire"))
-            .body("offenderMatchDetails[0].address.postcode", equalTo("S10 2NA"))
-            .body("offenderMatchDetails[0].matchIdentifiers.crn", equalTo("X320741"))
-            .body("offenderMatchDetails[0].matchIdentifiers.pnc", equalTo("2004/0712343H"))
-            .body("offenderMatchDetails[0].matchIdentifiers.cro", equalTo("123456/04A"))
-            .body("offenderMatchDetails[0].probationStatus", equalTo("Previously known"))
-            .body("offenderMatchDetails[0].probationStatusActual", equalTo("PREVIOUSLY_KNOWN"))
-            .body("offenderMatchDetails[0].mostRecentEvent.text", equalTo("CJA - Indeterminate Public Prot."))
-            .body("offenderMatchDetails[0].mostRecentEvent.length", equalTo(5))
-            .body("offenderMatchDetails[0].mostRecentEvent.lengthUnits", equalTo("Years"))
-            .body("offenderMatchDetails[0].mostRecentEvent.startDate", equalTo("2014-01-01"))
+                .when()
+                .get(location)
+                .then()
+                .statusCode(200)
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("caseNo", equalTo("1600028913"))
+                .body("offenderMatches", hasSize(2))
+                .body("offenderMatches[0].crn", equalTo("X12345"))
+                .body("offenderMatches[0].pnc", equalTo(null))
+                .body("offenderMatches[0].cro", equalTo(null))
+                .body("offenderMatches[0].matchType", equalTo("PARTIAL_NAME"))
+                .body("offenderMatches[0].confirmed", equalTo(false))
+                .body("offenderMatches[0].rejected", equalTo(false))
+                .body("offenderMatches[1].matchType", equalTo("NAME_DOB_ALIAS"))
             ;
+        }
+
+        @Test
+        void givenCourtDoesNotExist_whenPostMadeToOffenderMatches_thenReturnNotFound() {
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(SINGLE_EXACT_MATCH_BODY)
+                .when()
+                .post("/court/FOO/case/1234567890/grouped-offender-matches")
+                .then()
+                .statusCode(404)
+                .body("userMessage", equalTo("Court FOO not found"))
+                .body("developerMessage", equalTo("Court FOO not found"));
+        }
+
+        @Test
+        void givenCaseDoesNotExist_whenPostMadeToOffenderMatches_thenReturnNotFound() {
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(SINGLE_EXACT_MATCH_BODY)
+                .when()
+                .post("/court/" + COURT_CODE + "/case/1234567890/grouped-offender-matches")
+                .then()
+                .statusCode(404)
+                .body("userMessage", equalTo("Case 1234567890 not found for court " + COURT_CODE))
+                .body("developerMessage", equalTo("Case 1234567890 not found for court " + COURT_CODE));
+        }
     }
 
-    @Test
-    void givenMatchWithNoConvictions_whenGetOffenderDetailMatch_thenReturn200WithNoMostRecentEvent() {
+    @Nested
+    class PostMatchRequestCaseId {
+        private static final String CASE_ID = "1f93aa0a-7e46-4885-a1cb-f25a4be33a18";
+        private static final String DEFENDANT_ID = "3e94df33-8165-448b-ade9-14a28408e377";
 
-        String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, "1000002");
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(APPLICATION_JSON_VALUE)
-            .contentType(APPLICATION_JSON_VALUE)
-            .when()
-            .get(path)
-            .then()
-            .statusCode(200)
-            .body("offenderMatchDetails", hasSize(1))
-            .body("offenderMatchDetails[0].title", equalTo(null))
-            .body("offenderMatchDetails[0].forename", equalTo("Nic"))
-            .body("offenderMatchDetails[0].middleNames", hasSize(0))
-            .body("offenderMatchDetails[0].surname", equalTo("Cage"))
-            .body("offenderMatchDetails[0].dateOfBirth", equalTo("1965-07-19"))
-            .body("offenderMatchDetails[0].address", equalTo(null))
-            .body("offenderMatchDetails[0].matchIdentifiers.crn", equalTo("X980123"))
-            .body("offenderMatchDetails[0].probationStatus", equalTo("Previously known"))
-            .body("offenderMatchDetails[0].probationStatusActual", equalTo("PREVIOUSLY_KNOWN"))
-            .body("offenderMatchDetails[0].mostRecentEvent", equalTo(null))
-        ;
+        @Test
+        void givenCourtCaseExistsWithNoPriorMatches_whenPostMadeToOffenderMatches_thenReturn201CreatedWithValidLocation() {
+            String location = given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(SINGLE_EXACT_MATCH_BODY)
+                .when()
+                .post("/case/" + CASE_ID + "/defendant/" + DEFENDANT_ID + "/grouped-offender-matches")
+                .then()
+                .statusCode(201)
+                .header("Location", matchesPattern("/case/" + CASE_ID + "/defendant/" + DEFENDANT_ID + "/grouped-offender-matches/[0-9]+"))
+                .extract()
+                .header("Location");
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get(location)
+                .then()
+                .statusCode(200)
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("caseNo", equalTo("1600028918"))
+                .body("offenderMatches", hasSize(1))
+                .body("offenderMatches[0].crn", equalTo("X346204"))
+                .body("offenderMatches[0].pnc", equalTo("pnc123"))
+                .body("offenderMatches[0].cro", equalTo("cro456"))
+                .body("offenderMatches[0].matchType", equalTo("NAME_DOB"))
+                .body("offenderMatches[0].confirmed", equalTo(true));
+        }
+
+        @Test
+        void givenCourtCaseExistsWithPriorMatches_whenPostMadeToOffenderMatches_thenReturn201CreatedWithValidLocation() {
+
+            String caseId = "1f93aa0a-7e46-4885-a1cb-f25a4be33a00";
+            String defendantId = "40db17d6-04db-11ec-b2d8-0242ac130002";
+
+            String location = given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(MULTIPLE_NON_EXACT_MATCH_BODY)
+                .when()
+                .post("/case/" + caseId + "/defendant/" + defendantId + "/grouped-offender-matches")
+                .then()
+                .statusCode(201)
+                .header("Location", matchesPattern("/case/" + caseId + "/defendant/" + defendantId + "/grouped-offender-matches/[0-9]+"))
+                .extract()
+                .header("Location");
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get(location)
+                .then()
+                .statusCode(200)
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("caseNo", equalTo("1600028913"))
+                .body("offenderMatches", hasSize(2))
+                .body("offenderMatches[0].crn", equalTo("X12345"))
+                .body("offenderMatches[0].pnc", equalTo(null))
+                .body("offenderMatches[0].cro", equalTo(null))
+                .body("offenderMatches[0].matchType", equalTo("PARTIAL_NAME"))
+                .body("offenderMatches[0].confirmed", equalTo(false))
+                .body("offenderMatches[0].rejected", equalTo(false))
+                .body("offenderMatches[1].matchType", equalTo("NAME_DOB_ALIAS"))
+            ;
+        }
+
+        @Test
+        void givenCourtCaseDoesNotExist_whenPostMadeToOffenderMatches_thenReturn404() {
+
+            String caseId = "1f93aa0a-7e46-4775-a1cb-f11a4be33a00";
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(MULTIPLE_NON_EXACT_MATCH_BODY)
+                .when()
+                .post("/case/" + caseId + "/defendant/" + DEFENDANT_ID + "/grouped-offender-matches")
+                .then()
+                .statusCode(404)
+                .body("userMessage", equalTo("Case " + caseId + " not found"))
+                .body("developerMessage", equalTo("Case " + caseId + " not found"))
+            ;
+        }
+
     }
 
-    @Test
-    void givenCaseDoesNotExist_whenGetOffenderDetailMatch_thenReturnNotFound() {
-        String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, "23456541141414");
-        given()
-            .auth()
-            .oauth2(getToken())
-            .accept(APPLICATION_JSON_VALUE)
-            .contentType(APPLICATION_JSON_VALUE)
-            .when()
-            .get(path)
-            .then()
-            .statusCode(404)
-            .body("userMessage", equalTo("Case 23456541141414 not found for court " + COURT_CODE))
-            .body("developerMessage" , equalTo("Case 23456541141414 not found for court " + COURT_CODE));
+    @Nested
+    class MatchDetail {
+
+        private static final String CASE_NO = "1600028913";
+        @Test
+        void givenMultipleMatchesOneNotFound_whenGetOffenderDetailMatch_thenReturn200() {
+
+            String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, CASE_NO);
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body("offenderMatchDetails", hasSize(1))
+                .body("offenderMatchDetails[0].title", equalTo("Mr."))
+                .body("offenderMatchDetails[0].forename", equalTo("Aadland"))
+                .body("offenderMatchDetails[0].middleNames", hasSize(2))
+                .body("offenderMatchDetails[0].middleNames[0]", equalTo("Felix"))
+                .body("offenderMatchDetails[0].middleNames[1]", equalTo("Hope"))
+                .body("offenderMatchDetails[0].surname", equalTo("Bertrand"))
+                .body("offenderMatchDetails[0].dateOfBirth", equalTo("2000-07-19"))
+                .body("offenderMatchDetails[0].address.addressNumber", equalTo("19"))
+                .body("offenderMatchDetails[0].address.streetName", equalTo("Junction Road"))
+                .body("offenderMatchDetails[0].address.district", equalTo("Blackheath"))
+                .body("offenderMatchDetails[0].address.town", equalTo("Sheffield"))
+                .body("offenderMatchDetails[0].address.county", equalTo("South Yorkshire"))
+                .body("offenderMatchDetails[0].address.postcode", equalTo("S10 2NA"))
+                .body("offenderMatchDetails[0].matchIdentifiers.crn", equalTo("X320741"))
+                .body("offenderMatchDetails[0].matchIdentifiers.pnc", equalTo("2004/0712343H"))
+                .body("offenderMatchDetails[0].matchIdentifiers.cro", equalTo("123456/04A"))
+                .body("offenderMatchDetails[0].probationStatus", equalTo("Previously known"))
+                .body("offenderMatchDetails[0].probationStatusActual", equalTo("PREVIOUSLY_KNOWN"))
+                .body("offenderMatchDetails[0].mostRecentEvent.text", equalTo("CJA - Indeterminate Public Prot."))
+                .body("offenderMatchDetails[0].mostRecentEvent.length", equalTo(5))
+                .body("offenderMatchDetails[0].mostRecentEvent.lengthUnits", equalTo("Years"))
+                .body("offenderMatchDetails[0].mostRecentEvent.startDate", equalTo("2014-01-01"))
+            ;
+        }
+
+        @Test
+        void givenMatchWithNoConvictions_whenGetOffenderDetailMatch_thenReturn200WithNoMostRecentEvent() {
+
+            String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, "1000002");
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body("offenderMatchDetails", hasSize(1))
+                .body("offenderMatchDetails[0].title", equalTo(null))
+                .body("offenderMatchDetails[0].forename", equalTo("Nic"))
+                .body("offenderMatchDetails[0].middleNames", hasSize(0))
+                .body("offenderMatchDetails[0].surname", equalTo("Cage"))
+                .body("offenderMatchDetails[0].dateOfBirth", equalTo("1965-07-19"))
+                .body("offenderMatchDetails[0].address", equalTo(null))
+                .body("offenderMatchDetails[0].matchIdentifiers.crn", equalTo("X980123"))
+                .body("offenderMatchDetails[0].probationStatus", equalTo("Previously known"))
+                .body("offenderMatchDetails[0].probationStatusActual", equalTo("PREVIOUSLY_KNOWN"))
+                .body("offenderMatchDetails[0].mostRecentEvent", equalTo(null))
+            ;
+        }
+
+        @Test
+        void givenCaseDoesNotExist_whenGetOffenderDetailMatch_thenReturnNotFound() {
+            String path = String.format(OFFENDER_MATCHES_DETAIL_PATH, COURT_CODE, "23456541141414");
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get(path)
+                .then()
+                .statusCode(404)
+                .body("userMessage", equalTo("Case 23456541141414 not found for court " + COURT_CODE))
+                .body("developerMessage", equalTo("Case 23456541141414 not found for court " + COURT_CODE));
+        }
     }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderMatchServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderMatchServiceTest.java
@@ -1,9 +1,12 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
 
+import lombok.Data;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
@@ -33,14 +36,15 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OffenderMatchServiceTest {
-    public static final String COURT_CODE = "SHF";
+    public static final String COURT_CODE = "B10JQ";
     public static final String CASE_NO = "123456789";
-    public static final long ID = 1234L;
+
     @Mock
     private OffenderRestClientFactory offenderRestClientFactory;
     @Mock
@@ -50,212 +54,290 @@ class OffenderMatchServiceTest {
     @Mock
     private GroupedOffenderMatchRepository offenderMatchRepository;
     @Mock
-    private CourtCaseEntity courtCaseEntity;
-    @Mock
     private GroupedOffenderMatchesEntity groupedOffenderMatchesEntity;
     @Mock
     private GroupedOffenderMatchesRequest groupedOffenderMatchesRequest;
+    @Mock
+    private CourtCaseEntity courtCaseEntity;
 
     private OffenderMatchService service;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(offenderRestClientFactory.build()).thenReturn(offenderRestClient);
         service = new OffenderMatchService(courtCaseService, offenderMatchRepository, offenderRestClientFactory);
     }
 
-    @Test
-    void givenValidRequest_whenCreateGroupedMatchesCalled_thenCreateAndReturnMatch() {
-        when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.empty());
-        when(courtCaseService.getCaseByCaseNumber(COURT_CODE, CASE_NO)).thenReturn(courtCaseEntity);
-        when(offenderMatchRepository.save(any(GroupedOffenderMatchesEntity.class))).thenReturn(groupedOffenderMatchesEntity);
+    @Nested
+    class CreateOrUpdateByCourtAndCaseNo {
 
-        Optional<GroupedOffenderMatchesEntity> match = service.createOrUpdateGroupedMatches(COURT_CODE, CASE_NO, groupedOffenderMatchesRequest).blockOptional();
+        @Test
+        void givenValidRequest_whenCreateGroupedMatchesCalled_thenCreateAndReturnMatch() {
+            when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.empty());
+            when(courtCaseService.getCaseByCaseNumber(COURT_CODE, CASE_NO)).thenReturn(courtCaseEntity);
+            when(offenderMatchRepository.save(any(GroupedOffenderMatchesEntity.class))).thenReturn(groupedOffenderMatchesEntity);
 
-        assertThat(match).isPresent();
-        assertThat(match.get()).isEqualTo(groupedOffenderMatchesEntity);
+            Optional<GroupedOffenderMatchesEntity> match = service.createOrUpdateGroupedMatches(COURT_CODE, CASE_NO, groupedOffenderMatchesRequest)
+                .blockOptional();
+
+            assertThat(match).isPresent();
+            assertThat(match.get()).isEqualTo(groupedOffenderMatchesEntity);
+        }
+
+        @Test
+        void givenValidRequest_whenUpdateGroupedMatchesCalled_thenCreateAndReturnMatch() {
+
+            when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
+            when(offenderMatchRepository.save(any(GroupedOffenderMatchesEntity.class))).thenReturn(groupedOffenderMatchesEntity);
+
+            Optional<GroupedOffenderMatchesEntity> match = service.createOrUpdateGroupedMatches(COURT_CODE, CASE_NO, groupedOffenderMatchesRequest)
+                .blockOptional();
+
+            assertThat(match).isPresent();
+            assertThat(match.get()).isEqualTo(groupedOffenderMatchesEntity);
+        }
     }
 
-    @Test
-    void givenValidRequest_whenUpdateGroupedMatchesCalled_thenCreateAndReturnMatch() {
+    @Nested
+    class CreateOrUpdateByCaseId {
 
-        when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
-        when(offenderMatchRepository.save(any(GroupedOffenderMatchesEntity.class))).thenReturn(groupedOffenderMatchesEntity);
+        private static final String CASE_ID = "f1e1867f-94a5-45a2-81cf-92780a51564d";
+        private static final String DEFENDANT_ID = "378752d2-2a60-42d9-8f70-89d6fa022be4";
 
-        Optional<GroupedOffenderMatchesEntity> match = service.createOrUpdateGroupedMatches(COURT_CODE, CASE_NO, groupedOffenderMatchesRequest).blockOptional();
-
-        assertThat(match).isPresent();
-        assertThat(match.get()).isEqualTo(groupedOffenderMatchesEntity);
-    }
-
-    @Test
-    void givenValidRequest_whenGetGroupedMatches_thenReturnValidMatch() {
-        when(groupedOffenderMatchesEntity.getCourtCode()).thenReturn(COURT_CODE);
-        when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
-        when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
-
-        Optional<GroupedOffenderMatchesEntity> entity = service.getGroupedMatches(COURT_CODE, CASE_NO, ID).blockOptional();
-        assertThat(entity).isPresent();
-        assertThat(entity.get()).isEqualTo(groupedOffenderMatchesEntity);
-    }
-
-    @Test
-    void givenCourtCodeDoesNotMatch_whenGetGroupedMatches_thenThrowEntityNotFound() {
-        when(groupedOffenderMatchesEntity.getCourtCode()).thenReturn(COURT_CODE);
-        when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
-        when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
-
-        assertThatExceptionOfType(EntityNotFoundException.class)
-                .isThrownBy(() -> service.getGroupedMatches("BAD_CODE", CASE_NO, ID).blockOptional());
-    }
-
-    @Test
-    void givenCaseNoDoesNotMatch_whenGetGroupedMatches_thenThrowEntityNotFound() {
-        when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
-        when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
-
-        assertThatExceptionOfType(EntityNotFoundException.class)
-                .isThrownBy(() -> service.getGroupedMatches(COURT_CODE, "99999", ID).blockOptional());
-    }
-
-    @Test
-    void givenMultipleConvictionsIncludingNullDates_whenGetMostRecentSentence_theReturn() {
-        LocalDate date20July = LocalDate.of(2020, Month.JULY, 20);
-        LocalDate date21July = LocalDate.of(2020, Month.JULY, 21);
-        Sentence sentence3 = Sentence.builder().description("B").build();
-        Conviction conviction1 = Conviction.builder().sentence(Sentence.builder().description("A").build()).build();
-        Conviction conviction2 = Conviction.builder().convictionDate(date20July).sentence(Sentence.builder().description("B").build()).build();
-        Conviction conviction3 = Conviction.builder().convictionDate(date21July).sentence(sentence3).build();
-
-        Sentence sentence = service.getSentenceForMostRecentConviction(List.of(conviction1, conviction2, conviction3));
-
-        assertThat(sentence).isSameAs(sentence3);
-    }
-
-    @Test
-    void givenConvictionWithNoSentence_whenGetMostRecentSentence_thenReturnNull() {
-        Sentence sentence = service.getSentenceForMostRecentConviction(List.of(Conviction.builder().build()));
-
-        assertThat(sentence).isNull();
-    }
-
-    @Test
-    void givenNullInput_whenGetMostRecentSentence_thenReturnNull() {
-        assertThat(service.getSentenceForMostRecentConviction(null)).isNull();
-    }
-
-    @Test
-    void whenGetOffenderMatchDetail_thenReturn() {
-        Conviction conviction = buildConviction(true, "sentence1");
-        OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
-        String crn = "X320741";
-        mockOffenderDetailMatch(crn, matchDetail, List.of(conviction));
-
-        OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail(crn);
-
-        verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
-        verify(offenderRestClient).getConvictionsByCrn(crn);
-        assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
-        assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
-    }
-
-    @Test
-    void givenNoConvictions_whenGetOffenderMatchDetail_thenReturn() {
-
-        OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
-        String crn = "X320741";
-        mockOffenderDetailMatch(crn, matchDetail, Collections.emptyList());
-
-        OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
-
-        assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
-        verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
-        verify(offenderRestClient).getConvictionsByCrn(crn);
-        assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
-    }
-
-    @Test
-    void given404OnConvictionsCall_whenGetOffenderMatchDetail_thenReturn() {
-
-        OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
-        String crn = "X320741";
-        when(offenderRestClient.getOffenderMatchDetailByCrn(crn)).thenReturn(Mono.justOrEmpty(matchDetail));
-        when(offenderRestClient.getConvictionsByCrn(crn)).thenReturn(Mono.error( new OffenderNotFoundException(crn)));
-        when(offenderRestClient.getProbationStatusByCrn(crn)).thenReturn(Mono.just(ProbationStatusDetail.builder().status("CURRENT").build()));
-
-        OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
-
-        assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
-        assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
-    }
-
-    @Test
-    void givenNoMatchDetail_whenGetOffenderMatchDetail_thenReturnNull() {
-
-        String crn = "X320741";
-        Conviction conviction = buildConviction(true, "sentence1");
-        mockOffenderDetailMatch(crn, null, List.of(conviction));
-
-        OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
-
-        assertThat(offenderMatchDetail).isNull();
-        verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
-        verify(offenderRestClient).getConvictionsByCrn(crn);
-        verify(offenderRestClient).getProbationStatusByCrn(crn);
-    }
-
-    @Test
-    void givenMultipleCrns_whenGetOffenderMatchDetails_thenReturn() {
-
-        String crn1 = "X320741";
-        String crn2 = "X320742";
-
-        when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.ofNullable(buildGroupedOffenderMatchesEntity(List.of(crn1, crn2))));
-
-        Conviction conviction1 = buildConviction(true, "sentence1");
-        Conviction conviction2 = buildConviction(false, "sentence2");
-        OffenderMatchDetail matchDetail1 = OffenderMatchDetail.builder().forename("Chris").build();
-        OffenderMatchDetail matchDetail2 = OffenderMatchDetail.builder().forename("Dave").build();
-
-        mockOffenderDetailMatch(crn1, matchDetail1, Collections.emptyList());
-        mockOffenderDetailMatch(crn2, matchDetail2, List.of(conviction2, conviction1));
-
-        OffenderMatchDetailResponse response = service.getOffenderMatchDetails(COURT_CODE, CASE_NO);
-
-        assertThat(response.getOffenderMatchDetails()).hasSize(2);
-        assertThat(response.getOffenderMatchDetails()).extracting("forename").containsExactlyInAnyOrder("Chris", "Dave");
-    }
-
-    @Test
-    void whenGetOffenderMatchCount_thenReturn() {
-
-        when(offenderMatchRepository.getMatchCount(COURT_CODE, CASE_NO)).thenReturn(Optional.ofNullable(2));
-
-        assertThat(service.getMatchCount(COURT_CODE, CASE_NO).get()).isEqualTo(2);
-    }
-
-    private void mockOffenderDetailMatch(String crn, OffenderMatchDetail matchDetail, List<Conviction> convictions) {
-        when(offenderRestClient.getOffenderMatchDetailByCrn(crn)).thenReturn(Mono.justOrEmpty(matchDetail));
-        when(offenderRestClient.getConvictionsByCrn(crn)).thenReturn(Mono.just(convictions));
-        when(offenderRestClient.getProbationStatusByCrn(crn)).thenReturn(Mono.just(ProbationStatusDetail.builder().status("CURRENT").build()));
-    }
-
-    private Conviction buildConviction(boolean active, String sentenceDesc) {
-        LocalDate date = LocalDate.of(2020, Month.JULY, 20);
-        Sentence sentence = Sentence.builder().description(sentenceDesc).build();
-        return Conviction.builder()
-            .active(active)
-            .convictionDate(date)
-            .sentence(sentence)
+        GroupedOffenderMatchesRequest request = GroupedOffenderMatchesRequest.builder()
+            .matches(Collections.emptyList())
             .build();
+
+        @Test
+        void givenNoExistingCase_whenCreateOrUpdate_thenCreate() {
+            when(offenderMatchRepository.findByCaseId(CASE_ID)).thenReturn(Optional.empty());
+            when(courtCaseEntity.getCaseId()).thenReturn(CASE_ID);
+            when(courtCaseService.getCaseByCaseId(CASE_ID)).thenReturn(courtCaseEntity);
+            when(offenderMatchRepository.save(argThat(new EntityMatcher(DEFENDANT_ID, CASE_ID)))).thenReturn(groupedOffenderMatchesEntity);
+
+            var match = service.createOrUpdateGroupedMatchesByDefendant(CASE_ID, DEFENDANT_ID, request).blockOptional();
+
+            assertThat(match).isPresent();
+            assertThat(match.get()).isEqualTo(groupedOffenderMatchesEntity);
+        }
+
+        @Test
+        void givenAnExistingCase_whenCreateOrUpdate_thenUpdate() {
+
+            // Group has no defendant ID to start with. Prove that the update has happened by asserting on it later
+            var groupEntity = GroupedOffenderMatchesEntity.builder().caseId(CASE_ID).offenderMatches(Collections.emptyList()).build();
+            when(offenderMatchRepository.findByCaseId(CASE_ID)).thenReturn(Optional.of(groupEntity));
+            when(offenderMatchRepository.save(groupEntity)).thenReturn(groupEntity);
+
+            var match = service.createOrUpdateGroupedMatchesByDefendant(CASE_ID, DEFENDANT_ID, request).blockOptional();
+
+            assertThat(match).isPresent();
+            assertThat(match.get()).isEqualTo(groupEntity);
+            assertThat(groupEntity.getDefendantId()).isEqualTo(DEFENDANT_ID);
+        }
+
+        @Data
+        class EntityMatcher implements ArgumentMatcher<GroupedOffenderMatchesEntity> {
+
+            private final String defendantId;
+            private final String caseId;
+
+            @Override
+            public boolean matches(GroupedOffenderMatchesEntity argument) {
+                return defendantId.equals(argument.getDefendantId()) && caseId.equals(argument.getCaseId());
+            }
+        }
     }
 
-    private GroupedOffenderMatchesEntity buildGroupedOffenderMatchesEntity(List<String> crns) {
+    @Nested
+    class GetGroupedMatchesByCourtAndCaseNo {
 
-        List<OffenderMatchEntity> offenderMatchEntities = crns.stream()
-            .map(crn -> OffenderMatchEntity.builder().crn(crn).build())
-            .collect(Collectors.toList());
+        public static final long ID = 1234L;
 
-        return GroupedOffenderMatchesEntity.builder().offenderMatches(offenderMatchEntities).build();
+        @Test
+        void givenValidRequest_whenGetGroupedMatches_thenReturnValidMatch() {
+            when(groupedOffenderMatchesEntity.getCourtCode()).thenReturn(COURT_CODE);
+            when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
+            when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
+
+            var entity = service.getGroupedMatches(COURT_CODE, CASE_NO, ID).blockOptional();
+            assertThat(entity).isPresent();
+            assertThat(entity.get()).isEqualTo(groupedOffenderMatchesEntity);
+        }
+
+        @Test
+        void givenCourtCodeDoesNotMatch_whenGetGroupedMatches_thenThrowEntityNotFound() {
+            when(groupedOffenderMatchesEntity.getCourtCode()).thenReturn(COURT_CODE);
+            when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
+            when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
+
+            assertThatExceptionOfType(EntityNotFoundException.class)
+                .isThrownBy(() -> service.getGroupedMatches("BAD_CODE", CASE_NO, ID).blockOptional());
+        }
+
+        @Test
+        void givenCaseNoDoesNotMatch_whenGetGroupedMatches_thenThrowEntityNotFound() {
+            when(groupedOffenderMatchesEntity.getCaseNo()).thenReturn(CASE_NO);
+            when(offenderMatchRepository.findById(ID)).thenReturn(Optional.of(groupedOffenderMatchesEntity));
+
+            assertThatExceptionOfType(EntityNotFoundException.class)
+                .isThrownBy(() -> service.getGroupedMatches(COURT_CODE, "99999", ID).blockOptional());
+        }
     }
+
+    @Nested
+    class GetSentence {
+
+        @Test
+        void givenMultipleConvictionsIncludingNullDates_whenGetMostRecentSentence_theReturn() {
+            LocalDate date20July = LocalDate.of(2020, Month.JULY, 20);
+            LocalDate date21July = LocalDate.of(2020, Month.JULY, 21);
+            Sentence sentence3 = Sentence.builder().description("B").build();
+            Conviction conviction1 = Conviction.builder().sentence(Sentence.builder().description("A").build()).build();
+            Conviction conviction2 = Conviction.builder().convictionDate(date20July).sentence(Sentence.builder().description("B").build()).build();
+            Conviction conviction3 = Conviction.builder().convictionDate(date21July).sentence(sentence3).build();
+
+            Sentence sentence = service.getSentenceForMostRecentConviction(List.of(conviction1, conviction2, conviction3));
+
+            assertThat(sentence).isSameAs(sentence3);
+        }
+
+        @Test
+        void givenConvictionWithNoSentence_whenGetMostRecentSentence_thenReturnNull() {
+            Sentence sentence = service.getSentenceForMostRecentConviction(List.of(Conviction.builder().build()));
+
+            assertThat(sentence).isNull();
+        }
+
+        @Test
+        void givenNullInput_whenGetMostRecentSentence_thenReturnNull() {
+            assertThat(service.getSentenceForMostRecentConviction(null)).isNull();
+        }
+
+    }
+
+    @Nested
+    class GetOffenderMatchDetail {
+
+        @Test
+        void whenGetOffenderMatchDetail_thenReturn() {
+            Conviction conviction = buildConviction(true, "sentence1");
+            OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
+            String crn = "X320741";
+            mockOffenderDetailMatch(crn, matchDetail, List.of(conviction));
+
+            OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail(crn);
+
+            verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
+            verify(offenderRestClient).getConvictionsByCrn(crn);
+            assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
+            assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
+        }
+
+        @Test
+        void givenNoConvictions_whenGetOffenderMatchDetail_thenReturn() {
+
+            OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
+            String crn = "X320741";
+            mockOffenderDetailMatch(crn, matchDetail, Collections.emptyList());
+
+            OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
+
+            assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
+            verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
+            verify(offenderRestClient).getConvictionsByCrn(crn);
+            assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
+        }
+
+        @Test
+        void given404OnConvictionsCall_whenGetOffenderMatchDetail_thenReturn() {
+
+            OffenderMatchDetail matchDetail = OffenderMatchDetail.builder().forename("Chris").build();
+            String crn = "X320741";
+            when(offenderRestClient.getOffenderMatchDetailByCrn(crn)).thenReturn(Mono.justOrEmpty(matchDetail));
+            when(offenderRestClient.getConvictionsByCrn(crn)).thenReturn(Mono.error(new OffenderNotFoundException(crn)));
+            when(offenderRestClient.getProbationStatusByCrn(crn)).thenReturn(Mono.just(ProbationStatusDetail.builder().status("CURRENT").build()));
+
+            OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
+
+            assertThat(offenderMatchDetail.getForename()).isEqualTo("Chris");
+            assertThat(offenderMatchDetail.getProbationStatus()).isEqualTo(ProbationStatus.CURRENT);
+        }
+
+        @Test
+        void givenNoMatchDetail_whenGetOffenderMatchDetail_thenReturnNull() {
+
+            String crn = "X320741";
+            Conviction conviction = buildConviction(true, "sentence1");
+            mockOffenderDetailMatch(crn, null, List.of(conviction));
+
+            OffenderMatchDetail offenderMatchDetail = service.getOffenderMatchDetail("X320741");
+
+            assertThat(offenderMatchDetail).isNull();
+            verify(offenderRestClient).getOffenderMatchDetailByCrn(crn);
+            verify(offenderRestClient).getConvictionsByCrn(crn);
+            verify(offenderRestClient).getProbationStatusByCrn(crn);
+        }
+
+        @Test
+        void givenMultipleCrns_whenGetOffenderMatchDetails_thenReturn() {
+
+            String crn1 = "X320741";
+            String crn2 = "X320742";
+
+            when(offenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(
+                Optional.ofNullable(buildGroupedOffenderMatchesEntity(List.of(crn1, crn2))));
+
+            Conviction conviction1 = buildConviction(true, "sentence1");
+            Conviction conviction2 = buildConviction(false, "sentence2");
+            OffenderMatchDetail matchDetail1 = OffenderMatchDetail.builder().forename("Chris").build();
+            OffenderMatchDetail matchDetail2 = OffenderMatchDetail.builder().forename("Dave").build();
+
+            mockOffenderDetailMatch(crn1, matchDetail1, Collections.emptyList());
+            mockOffenderDetailMatch(crn2, matchDetail2, List.of(conviction2, conviction1));
+
+            OffenderMatchDetailResponse response = service.getOffenderMatchDetails(COURT_CODE, CASE_NO);
+
+            assertThat(response.getOffenderMatchDetails()).hasSize(2);
+            assertThat(response.getOffenderMatchDetails()).extracting("forename").containsExactlyInAnyOrder("Chris", "Dave");
+        }
+
+        private GroupedOffenderMatchesEntity buildGroupedOffenderMatchesEntity(List<String> crns) {
+
+            List<OffenderMatchEntity> offenderMatchEntities = crns.stream()
+                .map(crn -> OffenderMatchEntity.builder().crn(crn).build())
+                .collect(Collectors.toList());
+
+            return GroupedOffenderMatchesEntity.builder().offenderMatches(offenderMatchEntities).build();
+        }
+
+        private void mockOffenderDetailMatch(String crn, OffenderMatchDetail matchDetail, List<Conviction> convictions) {
+            when(offenderRestClient.getOffenderMatchDetailByCrn(crn)).thenReturn(Mono.justOrEmpty(matchDetail));
+            when(offenderRestClient.getConvictionsByCrn(crn)).thenReturn(Mono.just(convictions));
+            when(offenderRestClient.getProbationStatusByCrn(crn)).thenReturn(Mono.just(ProbationStatusDetail.builder().status("CURRENT").build()));
+        }
+
+        private Conviction buildConviction(boolean active, String sentenceDesc) {
+            LocalDate date = LocalDate.of(2020, Month.JULY, 20);
+            Sentence sentence = Sentence.builder().description(sentenceDesc).build();
+            return Conviction.builder()
+                .active(active)
+                .convictionDate(date)
+                .sentence(sentence)
+                .build();
+        }
+    }
+
+    @Nested
+    class MatchCount {
+
+        @Test
+        void whenGetOffenderMatchCount_thenReturn() {
+
+            when(offenderMatchRepository.getMatchCount(COURT_CODE, CASE_NO)).thenReturn(Optional.ofNullable(2));
+
+            assertThat(service.getMatchCount(COURT_CODE, CASE_NO).get()).isEqualTo(2);
+        }
+    }
+
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/OffenderMatchMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/OffenderMatchMapperTest.java
@@ -1,76 +1,79 @@
 package uk.gov.justice.probation.courtcaseservice.service.mapper;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.probation.courtcaseservice.controller.model.GroupedOffenderMatchesRequest;
 import uk.gov.justice.probation.courtcaseservice.controller.model.MatchIdentifiers;
 import uk.gov.justice.probation.courtcaseservice.controller.model.OffenderMatchRequest;
-import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.GroupedOffenderMatchesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderMatchEntity;
 import uk.gov.justice.probation.courtcaseservice.service.model.MatchType;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CASE_ID;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.COURT_CODE;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CRN;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_ID;
 
 class OffenderMatchMapperTest {
 
-    public static final long CASE_ID = 123L;
     public static final String CASE_NO = "1234";
 
+    private static final OffenderMatchRequest matchRequest1 = OffenderMatchRequest.builder()
+        .matchType(MatchType.NAME)
+        .confirmed(true)
+        .rejected(false)
+        .matchIdentifiers(new MatchIdentifiers("CRN1", "PNC1", "CRO1"))
+        .build();
+
+    private static final OffenderMatchRequest matchRequest2 = OffenderMatchRequest.builder()
+        .matchType(MatchType.NAME)
+        .confirmed(false)
+        .rejected(true)
+        .matchIdentifiers(new MatchIdentifiers("CRN2", "PNC2", "CRO2"))
+        .build();
+
     @Test
-    public void givenMultipleMatches_thenMapAllFields() {
+    void givenMultipleMatches_whenNewEntity_thenMapAllFields() {
         var courtCaseEntity = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
         var groupedOffenderMatchesRequest = GroupedOffenderMatchesRequest.builder()
-                .matches(Arrays.asList(OffenderMatchRequest.builder()
-                            .matchType(MatchType.NAME)
-                            .confirmed(true)
-                            .rejected(false)
-                            .matchIdentifiers(new MatchIdentifiers("CRN1", "PNC1", "CRO1"))
-                            .build(),
-                        OffenderMatchRequest.builder()
-                                .matchType(MatchType.NAME)
-                                .confirmed(false)
-                                .rejected(true)
-                                .matchIdentifiers(new MatchIdentifiers("CRN2", "PNC2", "CRO2"))
-                                .build()))
+                .matches(asList(matchRequest1, matchRequest2))
                 .build();
         var matchesEntity = OffenderMatchMapper.newGroupedMatchesOf(groupedOffenderMatchesRequest, courtCaseEntity);
 
-        assertThat(matchesEntity.getOffenderMatches()).hasSize(2);
         assertThat(matchesEntity.getId()).isNull();
         assertThat(matchesEntity.getCourtCode()).isEqualTo(COURT_CODE);
         assertThat(matchesEntity.getCaseNo()).isEqualTo(CASE_NO);
 
-        var first = matchesEntity.getOffenderMatches().get(0);
-        assertThat(first.getGroup()).isEqualTo(matchesEntity);
-        assertThat(first.getConfirmed()).isEqualTo(true);
-        assertThat(first.getRejected()).isEqualTo(false);
-        assertThat(first.getCrn()).isEqualTo("CRN1");
-        assertThat(first.getPnc()).isEqualTo("PNC1");
-        assertThat(first.getCro()).isEqualTo("CRO1");
-        assertThat(first.getMatchType()).isEqualTo(MatchType.NAME);
-
-        var second = matchesEntity.getOffenderMatches().get(1);
-        assertThat(second.getGroup()).isEqualTo(matchesEntity);
-        assertThat(second.getConfirmed()).isEqualTo(false);
-        assertThat(second.getRejected()).isEqualTo(true);
-        assertThat(second.getCrn()).isEqualTo("CRN2");
-        assertThat(second.getPnc()).isEqualTo("PNC2");
-        assertThat(second.getCro()).isEqualTo("CRO2");
-        assertThat(second.getMatchType()).isEqualTo(MatchType.NAME);
+        assertThat(matchesEntity.getOffenderMatches()).hasSize(2);
+        checkMatches(matchesEntity.getOffenderMatches().get(0), matchesEntity.getOffenderMatches().get(1), matchesEntity);
     }
 
     @Test
-    public void givenZeroMatches_thenMapAllFields() {
-        var courtCaseEntity = CourtCaseEntity.builder()
-                .id(CASE_ID)
-                .build();
+    void givenMultipleMatches_whenNewEntityForExtended_thenMapAllFields() {
+        var courtCaseEntity = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
+        var groupedOffenderMatchesRequest = GroupedOffenderMatchesRequest.builder()
+            .matches(asList(matchRequest1, matchRequest2))
+            .build();
+        var matchesEntity = OffenderMatchMapper.newGroupedMatchesOf(DEFENDANT_ID, groupedOffenderMatchesRequest, courtCaseEntity);
+
+        assertThat(matchesEntity.getId()).isNull();
+        assertThat(matchesEntity.getCourtCode()).isEqualTo(COURT_CODE);
+        assertThat(matchesEntity.getCaseNo()).isEqualTo(CASE_NO);
+        assertThat(matchesEntity.getDefendantId()).isEqualTo(DEFENDANT_ID);
+        assertThat(matchesEntity.getCaseId()).isEqualTo(CASE_ID);
+
+        assertThat(matchesEntity.getOffenderMatches()).hasSize(2);
+        checkMatches(matchesEntity.getOffenderMatches().get(0), matchesEntity.getOffenderMatches().get(1), matchesEntity);
+    }
+
+    @Test
+    void givenZeroMatches_whenNewEntity_thenMapAllFields() {
+        var courtCaseEntity = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
         var groupedOffenderMatchesRequest = GroupedOffenderMatchesRequest.builder()
                 .matches(Collections.emptyList())
                 .build();
@@ -81,13 +84,7 @@ class OffenderMatchMapperTest {
     }
 
     @Test
-    public void whenUpdate_thenRefreshMatches() {
-        var courtCaseEntity = CourtCaseEntity.builder()
-            .id(CASE_ID)
-            .caseNo(CASE_NO)
-            .courtCode(COURT_CODE)
-            .build();
-
+    void whenUpdate_thenRefreshMatches() {
         var offenderMatchEntity = OffenderMatchEntity.builder()
             .matchType(MatchType.NAME_DOB)
             .confirmed(true)
@@ -96,22 +93,15 @@ class OffenderMatchMapperTest {
             .cro("CRO2")
             .pnc("PNC2")
             .build();
-        List<OffenderMatchEntity> offenderMatchEntities = new ArrayList<>();
-        offenderMatchEntities.add(offenderMatchEntity);
-        GroupedOffenderMatchesEntity existingEntity = GroupedOffenderMatchesEntity.builder()
+        var existingEntity = GroupedOffenderMatchesEntity.builder()
             .courtCode(COURT_CODE)
             .caseNo(CASE_NO)
             .id(99L)
-            .offenderMatches(offenderMatchEntities)
+            .offenderMatches(new ArrayList<>() {{ add(offenderMatchEntity); }})
             .build();
 
         var groupedOffenderMatchesRequest = GroupedOffenderMatchesRequest.builder()
-            .matches(List.of(OffenderMatchRequest.builder()
-                    .matchType(MatchType.NAME)
-                    .confirmed(true)
-                    .rejected(false)
-                    .matchIdentifiers(new MatchIdentifiers("CRN3", "PNC3", "CRO3"))
-                    .build()))
+            .matches(List.of(matchRequest1))
             .build();
         var matchesEntity = OffenderMatchMapper.update(existingEntity, groupedOffenderMatchesRequest);
 
@@ -124,10 +114,66 @@ class OffenderMatchMapperTest {
         assertThat(first.getGroup()).isEqualTo(matchesEntity);
         assertThat(first.getConfirmed()).isEqualTo(true);
         assertThat(first.getRejected()).isEqualTo(false);
-        assertThat(first.getCrn()).isEqualTo("CRN3");
-        assertThat(first.getPnc()).isEqualTo("PNC3");
-        assertThat(first.getCro()).isEqualTo("CRO3");
+        assertThat(first.getCrn()).isEqualTo("CRN1");
+        assertThat(first.getPnc()).isEqualTo("PNC1");
+        assertThat(first.getCro()).isEqualTo("CRO1");
         assertThat(first.getMatchType()).isEqualTo(MatchType.NAME);
     }
 
+    @Test
+    void givenExtendedRequest_whenUpdate_thenRefreshMatches() {
+        var offenderMatchEntity = OffenderMatchEntity.builder()
+            .matchType(MatchType.NAME_DOB)
+            .confirmed(true)
+            .rejected(false)
+            .crn("CRN2")
+            .cro("CRO2")
+            .pnc("PNC2")
+            .build();
+        var existingEntity = GroupedOffenderMatchesEntity.builder()
+            .courtCode(COURT_CODE)
+            .caseNo(CASE_NO)
+            .id(99L)
+            .offenderMatches(new ArrayList<>() {{ add(offenderMatchEntity); }})
+            .build();
+
+        var groupedOffenderMatchesRequest = GroupedOffenderMatchesRequest.builder()
+            .matches(List.of(matchRequest1))
+            .build();
+        var matchesEntity = OffenderMatchMapper.update(CASE_ID, DEFENDANT_ID, existingEntity, groupedOffenderMatchesRequest);
+
+        assertThat(matchesEntity.getOffenderMatches()).hasSize(1);
+        assertThat(matchesEntity).isSameAs(existingEntity);
+        assertThat(matchesEntity.getCourtCode()).isSameAs(COURT_CODE);
+        assertThat(matchesEntity.getCaseNo()).isSameAs(CASE_NO);
+        assertThat(matchesEntity.getDefendantId()).isEqualTo(DEFENDANT_ID);
+        assertThat(matchesEntity.getCaseId()).isEqualTo(CASE_ID);
+
+        var first = matchesEntity.getOffenderMatches().get(0);
+        assertThat(first.getGroup()).isEqualTo(matchesEntity);
+        assertThat(first.getConfirmed()).isEqualTo(true);
+        assertThat(first.getRejected()).isEqualTo(false);
+        assertThat(first.getCrn()).isEqualTo("CRN1");
+        assertThat(first.getPnc()).isEqualTo("PNC1");
+        assertThat(first.getCro()).isEqualTo("CRO1");
+        assertThat(first.getMatchType()).isEqualTo(MatchType.NAME);
+    }
+
+    void checkMatches(OffenderMatchEntity match1, OffenderMatchEntity match2, GroupedOffenderMatchesEntity group) {
+        assertThat(match1.getGroup()).isSameAs(group);
+        assertThat(match1.getConfirmed()).isEqualTo(true);
+        assertThat(match1.getRejected()).isEqualTo(false);
+        assertThat(match1.getCrn()).isEqualTo("CRN1");
+        assertThat(match1.getPnc()).isEqualTo("PNC1");
+        assertThat(match1.getCro()).isEqualTo("CRO1");
+        assertThat(match1.getMatchType()).isEqualTo(MatchType.NAME);
+
+        assertThat(match2.getGroup()).isSameAs(group);
+        assertThat(match2.getConfirmed()).isEqualTo(false);
+        assertThat(match2.getRejected()).isEqualTo(true);
+        assertThat(match2.getCrn()).isEqualTo("CRN2");
+        assertThat(match2.getPnc()).isEqualTo("PNC2");
+        assertThat(match2.getCro()).isEqualTo("CRO2");
+        assertThat(match2.getMatchType()).isEqualTo(MatchType.NAME);
+    }
 }

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -128,8 +128,8 @@ INSERT INTO courtcaseservicetest.OFFENCE (ID, COURT_CASE_ID, OFFENCE_TITLE, OFFE
 VALUES (1000002, 1000002, 'Title', 'Summary.', 'ACT.', 2);
 
 
-INSERT INTO courtcaseservicetest.offender_match_group(ID, CASE_NO, COURT_CODE)
-VALUES (9999991, '1600028913','B10JQ');
+INSERT INTO courtcaseservicetest.offender_match_group(ID, CASE_NO, COURT_CODE, CASE_ID, DEFENDANT_ID)
+VALUES (9999991, '1600028913','B10JQ', '1f93aa0a-7e46-4885-a1cb-f25a4be33a00', '40db17d6-04db-11ec-b2d8-0242ac130002');
 INSERT INTO courtcaseservicetest.offender_match_group(ID, CASE_NO, COURT_CODE)
 VALUES (9999992, '1600028914','B10JQ');
 


### PR DESCRIPTION
1. Allows for the saving of offender matches by case and defendant ID.
2. Adds case_id and defendant_id to the offender_match_group table, makes a compound index of these 2 fields and that is unique.
3. Migrates existing case and defendant IDs. There is a known issue whereby some latest case versions do not have defendant IDs. It has been  decided on slack that we will work around that in subsequent tickets for match detail and match counts by falling back to looking up defendant id from court code and case no
4. We will investigate further the source of the issue of missing defendant IDs