### PR TITLE
✨ PIC-1720 - add save by case and defendant id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 
     runtimeOnly 'org.flywaydb:flyway-core'
     runtimeOnly "org.springframework.boot:spring-boot-devtools"
-    runtimeOnly 'org.postgresql:postgresql:42.2.23'
+    runtimeOnly 'org.postgresql:postgresql:42.2.24'
 
     implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
     implementation ('org.springframework.boot:spring-boot-starter-webflux')

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -123,10 +123,10 @@ public class CourtCaseController {
                 .map(courtCaseEntity -> buildCourtCaseResponse(courtCaseEntity, true));
     }
 
-    @ApiOperation(value = "Saves and returns the court case entity data, by court and case number. ")
+    @ApiOperation(value = "Saves and returns the court case data, by case id.")
     @ApiResponses(
             value = {
-                    @ApiResponse(code = 501, message = "Not Implemented (To be 201 Created)", response = ExtendedCourtCaseRequest.class),
+                    @ApiResponse(code = 201, message = "Created", response = ExtendedCourtCaseRequest.class),
                     @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
                     @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
                     @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
@@ -140,6 +140,26 @@ public class CourtCaseController {
                                                      @Valid @RequestBody ExtendedCourtCaseRequest courtCaseRequest) {
         return courtCaseService.createCase(caseId, courtCaseRequest.asCourtCaseEntity())
             .thenReturn(courtCaseRequest);
+    }
+
+    @ApiOperation(value = "Saves and returns the court case data, by case id.")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 201, message = "Updated", response = ExtendedCourtCaseRequest.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not Found, if for example, the court code does not exist.", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @PutMapping(value = "/case/{caseId}/defendant/{defendantId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public @ResponseBody
+    Mono<CourtCaseResponse> updateCourtCaseByDefendantId(@PathVariable(value = "caseId") String caseId,
+        @PathVariable(value = "defendantId") String defendantId,
+        @Valid @RequestBody CourtCaseRequest courtCaseRequest) {
+        return courtCaseService.createUpdateCaseForSingleDefendantId(caseId, defendantId, courtCaseRequest.asEntity())
+            .map(courtCaseEntity -> buildCourtCaseResponseForCaseIdAndDefendantId(courtCaseEntity, defendantId));
     }
 
     @ApiOperation(value = "Gets case data for a court on a date. ",

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -223,7 +223,7 @@ public class CourtCaseController {
         final var offenderMatchesCount = offenderMatchService.getMatchCountByCaseIdAndDefendant(courtCaseEntity.getCaseId(), defendantId)
             .orElse(0);
 
-        return CourtCaseResponseMapper.mapFrom(courtCaseEntity, offenderMatchesCount, false, null);
+        return CourtCaseResponseMapper.mapFrom(courtCaseEntity, defendantId, offenderMatchesCount);
     }
 
     private CourtCaseResponse buildCourtCaseResponse(CourtCaseEntity courtCaseEntity, boolean includeCaseNo) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/CourtCaseEntity.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.With;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -33,7 +34,6 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 @ApiModel(description = "Court Case")
 @Entity
@@ -43,6 +43,7 @@ import java.util.Objects;
 @SuperBuilder
 @ToString(doNotUseGetters = true)
 @Getter
+@With
 @Table(name = "COURT_CASE")
 @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 public class CourtCaseEntity extends BaseImmutableEntity implements Serializable {
@@ -169,27 +170,6 @@ public class CourtCaseEntity extends BaseImmutableEntity implements Serializable
 
     public String getDefendantSurname() {
         return defendantName == null ? "" : defendantName.substring(defendantName.lastIndexOf(" ")+1);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (!(other instanceof CourtCaseEntity)) {
-            return false;
-        }
-
-        CourtCaseEntity that = (CourtCaseEntity) other;
-
-        return Objects.equals(this.caseNo, that.getCaseNo()) && Objects.equals(this.courtCode, that.getCourtCode());
-    }
-
-    @Override
-    public int hashCode() {
-        int result = getCaseNo() != null ? getCaseNo().hashCode() : 0;
-        result = 31 * result + (getCourtCode() != null ? getCourtCode().hashCode() : 0);
-        return result;
     }
 
 

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.With;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -33,6 +34,7 @@ import org.hibernate.annotations.Type;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @SuperBuilder
+@With
 @Getter
 @ToString
 @EqualsAndHashCode(callSuper = true, exclude = "courtCase")

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.With;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -28,6 +29,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @SuperBuilder
 @Getter
+@With
 @ToString(exclude = "courtCase")
 @EqualsAndHashCode(callSuper = true)
 public class HearingEntity extends BaseImmutableEntity implements Serializable {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CourtCaseService.java
@@ -19,6 +19,9 @@ public interface CourtCaseService {
     Mono<CourtCaseEntity> createCase(String caseId, CourtCaseEntity updatedCase)
         throws EntityNotFoundException, InputMismatchException;
 
+    Mono<CourtCaseEntity> createUpdateCaseForSingleDefendantId(String caseId, String defendantId, CourtCaseEntity updatedCase)
+        throws EntityNotFoundException, InputMismatchException;
+
     Mono<CourtCaseEntity> createCase(String courtCode, String caseNo, CourtCaseEntity updatedCase)
         throws EntityNotFoundException, InputMismatchException;
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -451,7 +451,47 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
 
             response.body("$", not(hasKey("caseNo")));
 
-            validateResponse(response, DECEMBER_14_9AM.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), CASE_ID);
+            response
+                .body("caseId", equalTo(CASE_ID))
+                .body("offences", hasSize(2))
+                .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+                .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+                .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+                .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+                .body("probationStatus", equalTo(PROBATION_STATUS))
+                .body("probationStatusActual", equalTo(null))
+                .body("previouslyKnownTerminationDate", equalTo(null))
+                .body("suspendedSentenceOrder", equalTo(false))
+                .body("breach", equalTo(false))
+                .body("source", equalTo("COMMON_PLATFORM"))
+                .body("preSentenceActivity", equalTo(false))
+                .body("crn", equalTo(null))
+                .body("pnc", equalTo("A/1234560BA"))
+                .body("cro", equalTo("311462/13E"))
+                .body("listNo", equalTo("3rd"))
+                .body("courtCode", equalTo(COURT_CODE))
+                .body("sessionStartTime", equalTo(DECEMBER_14_9AM.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+                .body("defendantName", equalTo("Mr Johnny BALL"))
+                .body("defendantId", equalTo(DEFENDANT_ID))
+                .body("name.title", equalTo("Mr"))
+                .body("name.forename1", equalTo("Johnny"))
+                .body("name.forename2", equalTo("John"))
+                .body("name.forename3", equalTo("Jon"))
+                .body("name.surname", equalTo("BALL"))
+                .body("defendantAddress.line1", equalTo("27"))
+                .body("defendantAddress.line2", equalTo("Elm Place"))
+                .body("defendantAddress.postcode", equalTo("ad21 5dr"))
+                .body("defendantAddress.line3", equalTo("Bangor"))
+                .body("defendantAddress.line4", equalTo(null))
+                .body("defendantAddress.line5", equalTo(null))
+                .body("defendantDob", equalTo(LocalDate.of(1958, Month.OCTOBER, 10).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                .body("defendantSex", equalTo("M"))
+                .body("nationality1", equalTo("British"))
+                .body("nationality2", equalTo("Polish"))
+                .body("removed", equalTo(false))
+                .body("createdToday", equalTo(true))
+                .body("numberOfPossibleMatches", equalTo(3))
+            ;
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerIntTest.java
@@ -199,12 +199,13 @@ public class CourtCaseControllerIntTest extends BaseIntTest {
         @Test
         void GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates() {
 
+            var futureDecember14 = LocalDate.of(2200, Month.DECEMBER, 14).format(DateTimeFormatter.ISO_DATE);
+
             given()
                 .auth()
                 .oauth2(getToken())
                 .when()
-                .get("/court/B30NY/cases?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00",
-                    DECEMBER_14.format(DateTimeFormatter.ISO_DATE))
+                .get("/court/B30NY/cases?date={date}&createdAfter=2020-09-01T16:59:59&createdBefore=2020-09-01T17:00:00", futureDecember14)
                 .then()
                 .assertThat()
                 .statusCode(200)

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.GroupedOffenderMatchRepository;
 
@@ -40,7 +41,6 @@ import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_1;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_2;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.PROBATION_STATUS;
-import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.aCourtCaseEntityLinked;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
@@ -436,7 +436,6 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
                 .ifPresentOrElse(entity -> {
                     assertThat(entity.getHearings()).hasSize(2);
                     assertThat(entity.getDefendants()).hasSize(2);
-                    assertThat(entity.getDefendants().get(0).getOffences()).hasSize(1);
                     assertThat(entity.getDefendants()).extracting("defendantId").containsExactlyInAnyOrder(defendantIdToUpdate, defendantIdToRetain);
                 }, () -> fail("COURT CASE does not exist for " + JSON_CASE_ID));
 
@@ -659,7 +658,7 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
     }
 
     private CourtCaseEntity createCaseDetails(String courtCode) {
-        return aCourtCaseEntityLinked(null, JSON_CASE_NO, LocalDateTime.now(), PROBATION_STATUS, JSON_CASE_ID, courtCode);
+        return EntityHelper.aCourtCase(null, JSON_CASE_NO, LocalDateTime.now(), PROBATION_STATUS, JSON_CASE_ID, courtCode);
     }
 
     private void createCase() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutIntTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,14 +15,17 @@ import uk.gov.justice.probation.courtcaseservice.BaseIntTest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.AddressPropertiesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
+import uk.gov.justice.probation.courtcaseservice.jpa.repository.GroupedOffenderMatchRepository;
 
 import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -36,7 +40,7 @@ import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_1;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.NATIONALITY_2;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.PROBATION_STATUS;
-import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.aCourtCaseEntity;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.aCourtCaseEntityLinked;
 import static uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper.getToken;
 
 @Sql(scripts = "classpath:before-test.sql", config = @SqlConfig(transactionMode = ISOLATED))
@@ -51,7 +55,11 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
     @Autowired
     CourtCaseRepository courtCaseRepository;
 
+    @Autowired
+    GroupedOffenderMatchRepository matchRepository;
+
     private static final String PUT_CASE_BY_CASENO_PATH = "/court/%s/case/%s";
+    private static final String PUT_BY_CASEID_AND_DEFENDANTID_PATH = "/case/%s/defendant/%s";
     private static final String CRN = "X320741";
     private static final String PNC = "A/1234560BA";
     private static final String COURT_ROOM = "1";
@@ -71,8 +79,8 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
 
     /** NEW values match those from JSON file incoming. */
     private static final String JSON_CASE_NO = "1700028914";
-    private static final String JSON_CASE_ID = "654321";
-
+    private static final String JSON_CASE_ID = "571b7172-4cef-435c-9048-d071a43b9dbf";
+    private static final String JSON_DEFENDANT_ID = "e0056894-e8f8-42c2-ba9a-e41250c3d1a3";
     @BeforeEach
     void beforeEach() throws Exception {
         caseDetailsJson = Files.readString(caseDetailsResource.getFile().toPath());
@@ -86,7 +94,7 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
         @Test
         void whenCreateCaseDataByCourtAndCaseNo_ThenCreateNewRecord() {
 
-            given()
+            var validatableResponse = given()
                 .auth()
                 .oauth2(getToken())
                 .contentType(ContentType.JSON)
@@ -96,40 +104,9 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
                 .put(String.format(PUT_CASE_BY_CASENO_PATH, COURT_CODE, JSON_CASE_NO))
                 .then()
                 .statusCode(201)
-                .body("caseNo", equalTo(JSON_CASE_NO))
-                .body("crn", equalTo(CRN))
-                .body("courtCode", equalTo(COURT_CODE))
-                .body("courtRoom", equalTo(COURT_ROOM))
-                .body("source", equalTo("LIBRA"))
-                .body("probationStatus", equalTo(PROBATION_STATUS))
-                .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
-                .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
-                .body("suspendedSentenceOrder", equalTo(true))
-                .body("preSentenceActivity", equalTo(true))
-                .body("breach", equalTo(true))
-                .body("defendantType", equalTo("PERSON"))
-                .body("defendantName", equalTo(DEFENDANT_NAME))
-                .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
-                .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
-                .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
-                .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
-                .body("defendantAddress.line4", equalTo(null))
-                .body("defendantAddress.line5", equalTo(null))
-                .body("offences", hasSize(2))
-                .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
-                .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
-                .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
-                .body("offences[0]", not(hasKey("courtCase")))
-                .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
-                .body("pnc", equalTo(PNC))
-                .body("listNo", equalTo(LIST_NO))
-                .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
-                .body("defendantSex", equalTo(DEFENDANT_SEX))
-                .body("defendantId", notNullValue())
-                .body("nationality1", equalTo(NATIONALITY_1))
-                .body("nationality2", equalTo(NATIONALITY_2))
-                .body("awaitingPsr", equalTo(true))
             ;
+
+            validateResponse(validatableResponse, JSON_CASE_ID, CRN, JSON_CASE_NO);
         }
 
         @Test
@@ -290,68 +267,8 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
     }
 
     @Nested
-    class OffenderMatches {
-
-        @Test
-        void whenUpdateCaseDataByCourtAndCaseNo_ThenUpdateOffenderMatchesConfirmedRejectedFlags() {
-
-            final var updatedJson = caseDetailsJson
-                .replace("\"caseNo\": \"1700028914\"", "\"caseNo\": \"1600028913\"")
-                .replace("\"crn\": \"X320741\"", "\"crn\": \"2234\"")
-                .replace("\"pnc\": \"A/1234560BA\"", "\"pnc\": \"223456\"")
-                .replace("\"cro\": \"99999\"", "\"cro\": \"22345\"");
-
-            given()
-                .auth()
-                .oauth2(getToken())
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .body(updatedJson)
-                .when()
-                .put(String.format(PUT_CASE_BY_CASENO_PATH, COURT_CODE, "1600028913"))
-                .then()
-                .statusCode(201)
-                .body("caseNo", equalTo("1600028913"))
-                .body("crn", equalTo("2234"))
-                .body("pnc", equalTo("223456"))
-            ;
-
-            given()
-                .auth()
-                .oauth2(getToken())
-                .accept(APPLICATION_JSON_VALUE)
-                .contentType(APPLICATION_JSON_VALUE)
-                .when()
-                .get("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches/9999991")
-                .then()
-                .statusCode(200)
-                .body("offenderMatches", hasSize(3))
-                .body("offenderMatches[1].crn", equalTo("X320741"))
-                .body("offenderMatches[1].confirmed", equalTo(false))
-                .body("offenderMatches[1].rejected", equalTo(true))
-            ;
-
-            given()
-                .auth()
-                .oauth2(getToken())
-                .accept(APPLICATION_JSON_VALUE)
-                .contentType(APPLICATION_JSON_VALUE)
-                .when()
-                .get("/court/" + COURT_CODE + "/case/1600028914/grouped-offender-matches/9999992")
-                .then()
-                .statusCode(200)
-                .body("offenderMatches[0].crn", equalTo("3234"))
-                .body("offenderMatches[0].confirmed", equalTo(false))
-                .body("offenderMatches[0].rejected", equalTo(true))
-            ;
-        }
-    }
-
-    @Nested
     class PutByCaseIdExtended {
-
         private static final String JSON_CASE_ID = "ac24a1be-939b-49a4-a524-21a3d228f8bc";
-
         @Test
         void whenCreateCaseExtendedByCaseId_thenCreateNewRecord() {
 
@@ -430,8 +347,319 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
         }
     }
 
+    @Nested
+    class PutByCaseIdAndSingleDefendantId {
+
+        private static final String LEICESTER_COURT_CODE = "B33HU";
+
+        @Test
+        void givenNewCaseWithSingleDefendantNoCrn_whenCreateCaseDataByCaseAndDefendantId_ThenCreateNewRecord() {
+
+            final var caseId = "aca6e1f4-e9fe-4ac4-b38e-5322bf770fd0";
+            final var defendantId = "c6df9428-8c81-4957-a67e-a0bfdd0351d3";
+            var updatedJson = caseDetailsJson
+                .replace("\"caseId\": \"571b7172-4cef-435c-9048-d071a43b9dbf\"", "\"caseId\": \"" + caseId + "\"")
+                .replace("\"defendantId\": \"e0056894-e8f8-42c2-ba9a-e41250c3d1a3\"", "\"defendantId\": \"" + defendantId + "\"")
+                .replace("\"crn\": \"X320741\"", "\"crn\": null")
+                ;
+
+            var validatableResponse = given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, defendantId))
+                .then()
+                .statusCode(201);
+
+            validateResponse(validatableResponse, caseId, null, null);
+
+            // All parts of the save are not in the response - so we check extra
+            courtCaseRepository.findByCaseId(caseId)
+                .ifPresentOrElse(entity -> {
+                    assertThat(entity.getHearings()).hasSize(1);
+                    assertThat(entity.getDefendants()).hasSize(1);
+                    assertThat(entity.getDefendants().get(0).getOffences()).hasSize(2);
+                }, () -> fail("COURT CASE does not exist for " + JSON_CASE_ID));
+        }
+
+        @Test
+        void givenExistingCase_whenUpdateCaseDataByCaseIdAndDefendantId_thenUpdateAllCrns() {
+
+            final var crn = "X320654";
+
+            final var caseNo = "1800028900";
+            final var caseId = "3db9d70b-10a2-49d1-b74d-379f2db74862";
+            final var defendantIdToUpdate = "1263de26-4a81-42d3-a798-bad802433318";
+            final var defendantIdToRetain = "6f014c2e-8be3-4a12-a551-8377bd31a7b8";
+            final var caseIdForSameCrn = "e652eaae-1114-4593-8f56-659eb2baffcf";
+
+            // Updated JSON will update the name
+            var updatedJson = caseDetailsJson
+                .replace("\"caseNo\": \"1700028914\"", "\"caseNo\": \"" + caseNo + "\"")
+                .replace("\"courtCode\": \"B10JQ\"", "\"courtCode\": \"" + LEICESTER_COURT_CODE + "\"")
+                .replace("\"caseId\": \"571b7172-4cef-435c-9048-d071a43b9dbf\"", "\"caseId\": \"" + caseId + "\"")
+                .replace("\"defendantId\": \"e0056894-e8f8-42c2-ba9a-e41250c3d1a3\"", "\"defendantId\": \"" + defendantIdToUpdate + "\"")
+                .replace("\"crn\": \"X320741\"", "\"crn\": \"" + crn + "\"")
+                ;
+
+            // This case ID is for the same CRN and will be updated from NO_RECORD to PREVIOUSLY_KNOWN
+            courtCaseRepository.findByCaseId(caseIdForSameCrn)
+                .ifPresentOrElse(entity -> {
+                    assertThat(entity.getCrn()).isEqualTo(crn);
+                    assertThat(entity.getProbationStatus()).isEqualTo("NO_RECORD");
+                }, () -> fail("COURT CASE does not exist for e652eaae-1114-4593-8f56-659eb2baffcf"));
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, defendantIdToUpdate))
+                .then()
+                .statusCode(201)
+                .body("caseNo", equalTo(null))
+                .body("courtCode", equalTo(LEICESTER_COURT_CODE))
+                .body("crn", equalTo(crn))
+                .body("defendantId", equalTo(defendantIdToUpdate))
+                .body("offences", hasSize(2))
+                .body("hearings", hasSize(2))
+                .body("probationStatusActual", equalTo("PREVIOUSLY_KNOWN"))
+            ;
+
+            // All parts of the save are not in the response - so we check extra
+            courtCaseRepository.findByCaseId(caseId)
+                .ifPresentOrElse(entity -> {
+                    assertThat(entity.getHearings()).hasSize(2);
+                    assertThat(entity.getDefendants()).hasSize(2);
+                    assertThat(entity.getDefendants().get(0).getOffences()).hasSize(1);
+                    assertThat(entity.getDefendants()).extracting("defendantId").containsExactlyInAnyOrder(defendantIdToUpdate, defendantIdToRetain);
+                }, () -> fail("COURT CASE does not exist for " + JSON_CASE_ID));
+
+            // Other case for same CRN has been updated to PREVIOUSLY_KNOWN
+            courtCaseRepository.findByCaseId(caseIdForSameCrn)
+                .ifPresentOrElse(entity -> {
+                    assertThat(entity.getCrn()).isEqualTo(crn);
+                    assertThat(entity.getProbationStatus()).isEqualTo("PREVIOUSLY_KNOWN");
+                }, () -> fail("COURT CASE does not exist for e652eaae-1114-4593-8f56-659eb2baffcf"));
+        }
+
+        @Test
+        void givenExistingCase_whenUpdateCaseDataByCaseIdAndDefendantId_thenUpdateCrnAndMatches() {
+
+            final var crn = "X320654";
+            final var caseNo = "1800028900";
+            final var caseId = "3db9d70b-10a2-49d1-b74d-379f2db74862";
+            final var defendantIdToUpdate = "1263de26-4a81-42d3-a798-bad802433318";
+
+            // Updated JSON will update the CRN
+            var updatedJson = caseDetailsJson
+                .replace("\"caseNo\": \"1700028914\"", "\"caseNo\": \"" + caseNo + "\"")
+                .replace("\"courtCode\": \"B10JQ\"", "\"courtCode\": \"" + LEICESTER_COURT_CODE + "\"")
+                .replace("\"caseId\": \"571b7172-4cef-435c-9048-d071a43b9dbf\"", "\"caseId\": \"" + caseId + "\"")
+                .replace("\"defendantId\": \"e0056894-e8f8-42c2-ba9a-e41250c3d1a3\"", "\"defendantId\": \"" + defendantIdToUpdate + "\"")
+                .replace("\"crn\": \"X320741\"", "\"crn\": \"" + crn + "\"")
+                ;
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, defendantIdToUpdate))
+                .then()
+                .statusCode(201)
+            ;
+
+            // In this test we want to look at the matches
+            var groupMatches = matchRepository.findByCaseIdAndDefendantId(caseId, defendantIdToUpdate);
+            groupMatches.ifPresentOrElse((matches) -> {
+                assertThat(matches.getOffenderMatches()).hasSize(2);
+                var confirmedMatch = matches.getOffenderMatches().stream()
+                    .filter(match -> crn.equals(match.getCrn()))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(confirmedMatch.getConfirmed()).isTrue();
+                assertThat(confirmedMatch.getRejected()).isFalse();
+
+                var otherMatches = matches.getOffenderMatches().stream()
+                    .filter(match -> !crn.equals(match.getCrn()))
+                    .collect(Collectors.toList());
+                assertThat(otherMatches).extracting("confirmed").containsOnly(Boolean.FALSE);
+                assertThat(otherMatches).extracting("rejected").containsOnly(Boolean.TRUE);
+            }, () -> fail("COURT CASE does not exist for e652eaae-1114-4593-8f56-659eb2baffcf"));
+
+        }
+
+        @Test
+        void givenNewCaseWithMismatchedCaseId_whenCreateCourtCase_ThenRaise400() {
+            final var caseId = "2dba205d-0562-4252-a6c7-f5d7e2dcd36f";
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(caseDetailsJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, "99999"))
+                .then()
+                .statusCode(400)
+                .body("developerMessage", equalTo("Case Id " + caseId + " does not match with value from body " + JSON_CASE_ID))
+            ;
+        }
+
+        @Test
+        void givenNewCaseWithMismatchedDefendantId_whenCreateCourtCase_ThenRaise400() {
+
+            final var defendantId = "2dba205d-0562-4252-a6c7-f5d7e2dcd36f";
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(caseDetailsJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, JSON_CASE_ID, defendantId))
+                .then()
+                .statusCode(400)
+                .body("developerMessage", equalTo("Defendant Id " + defendantId + " does not match the one in the CourtCaseEntity body as submitted " + JSON_DEFENDANT_ID))
+            ;
+        }
+
+        @Test
+        void givenUnknownCourtCodeInBody_whenUpdateCaseDataByCaseIdAndDefendantId_thenRaise404() {
+
+            final var unknownCourt = "X10XX";
+            final var caseId = "3db9d70b-10a2-49d1-b74d-379f2db74862";
+            final var defendantIdToUpdate = "1263de26-4a81-42d3-a798-bad802433318";
+
+            var updatedJson = caseDetailsJson
+                .replace("\"caseNo\": \"1700028914\"", "\"caseNo\": \"1800028900\"")
+                .replace("\"courtCode\": \"B10JQ\"", "\"courtCode\": \"" + unknownCourt + "\"")
+                .replace("\"caseId\": \"571b7172-4cef-435c-9048-d071a43b9dbf\"", "\"caseId\": \"" + caseId + "\"")
+                .replace("\"defendantId\": \"e0056894-e8f8-42c2-ba9a-e41250c3d1a3\"", "\"defendantId\": \"" + defendantIdToUpdate + "\"")
+                ;
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, defendantIdToUpdate))
+                .then()
+                .statusCode(404)
+                .body("developerMessage", equalTo("Court " + unknownCourt + " not found"))
+            ;
+        }
+    }
+
+    @Nested
+    class OffenderMatches {
+
+        @Test
+        void whenUpdateCaseDataByCourtAndCaseNo_ThenUpdateOffenderMatchesConfirmedRejectedFlags() {
+
+            final var updatedJson = caseDetailsJson
+                .replace("\"caseNo\": \"1700028914\"", "\"caseNo\": \"1600028913\"")
+                .replace("\"crn\": \"X320741\"", "\"crn\": \"2234\"")
+                .replace("\"pnc\": \"A/1234560BA\"", "\"pnc\": \"223456\"")
+                .replace("\"cro\": \"99999\"", "\"cro\": \"22345\"");
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(updatedJson)
+                .when()
+                .put(String.format(PUT_CASE_BY_CASENO_PATH, COURT_CODE, "1600028913"))
+                .then()
+                .statusCode(201)
+                .body("caseNo", equalTo("1600028913"))
+                .body("crn", equalTo("2234"))
+                .body("pnc", equalTo("223456"))
+            ;
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/court/" + COURT_CODE + "/case/1600028913/grouped-offender-matches/9999991")
+                .then()
+                .statusCode(200)
+                .body("offenderMatches", hasSize(3))
+                .body("offenderMatches[1].crn", equalTo("X320741"))
+                .body("offenderMatches[1].confirmed", equalTo(false))
+                .body("offenderMatches[1].rejected", equalTo(true))
+            ;
+
+            given()
+                .auth()
+                .oauth2(getToken())
+                .accept(APPLICATION_JSON_VALUE)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/court/" + COURT_CODE + "/case/1600028914/grouped-offender-matches/9999992")
+                .then()
+                .statusCode(200)
+                .body("offenderMatches[0].crn", equalTo("3234"))
+                .body("offenderMatches[0].confirmed", equalTo(false))
+                .body("offenderMatches[0].rejected", equalTo(true))
+            ;
+        }
+    }
+
+    private void validateResponse(ValidatableResponse validatableResponse, String caseId, String crn, String caseNo) {
+        validatableResponse.body("caseNo", equalTo(caseNo))
+            .body("caseId", equalTo(caseId))
+            .body("crn", equalTo(crn))
+            .body("courtCode", equalTo(COURT_CODE))
+            .body("courtRoom", equalTo(COURT_ROOM))
+            .body("source", equalTo("LIBRA"))
+            .body("probationStatus", equalTo(PROBATION_STATUS))
+            .body("sessionStartTime", equalTo(sessionStartTime.format(DateTimeFormatter.ISO_DATE_TIME)))
+            .body("previouslyKnownTerminationDate", equalTo(LocalDate.of(2018, 6, 24).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("suspendedSentenceOrder", equalTo(true))
+            .body("preSentenceActivity", equalTo(true))
+            .body("breach", equalTo(true))
+            .body("defendantType", equalTo("PERSON"))
+            .body("defendantName", equalTo(DEFENDANT_NAME))
+            .body("defendantAddress.line1", equalTo(ADDRESS.getLine1()))
+            .body("defendantAddress.line2", equalTo(ADDRESS.getLine2()))
+            .body("defendantAddress.postcode", equalTo(ADDRESS.getPostcode()))
+            .body("defendantAddress.line3", equalTo(ADDRESS.getLine3()))
+            .body("defendantAddress.line4", equalTo(null))
+            .body("defendantAddress.line5", equalTo(null))
+            .body("offences", hasSize(2))
+            .body("offences[0].offenceTitle", equalTo("Theft from a shop"))
+            .body("offences[0].offenceSummary", equalTo("On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person."))
+            .body("offences[0].act", equalTo("Contrary to section 1(1) and 7 of the Theft Act 1968."))
+            .body("offences[0]", not(hasKey("courtCase")))
+            .body("offences[1].offenceTitle", equalTo("Theft from a different shop"))
+            .body("pnc", equalTo(PNC))
+            .body("listNo", equalTo(LIST_NO))
+            .body("defendantDob", equalTo(LocalDate.of(1958, 12, 14).format(DateTimeFormatter.ISO_LOCAL_DATE)))
+            .body("defendantSex", equalTo(DEFENDANT_SEX))
+            .body("defendantId", notNullValue())
+            .body("nationality1", equalTo(NATIONALITY_1))
+            .body("nationality2", equalTo(NATIONALITY_2))
+            .body("awaitingPsr", equalTo(true))
+        ;
+    }
+
     private CourtCaseEntity createCaseDetails(String courtCode) {
-        return aCourtCaseEntity(null, JSON_CASE_NO, LocalDateTime.now(), PROBATION_STATUS, JSON_CASE_ID, courtCode);
+        return aCourtCaseEntityLinked(null, JSON_CASE_NO, LocalDateTime.now(), PROBATION_STATUS, JSON_CASE_ID, courtCode);
     }
 
     private void createCase() {
@@ -452,5 +680,26 @@ class CourtCaseControllerPutIntTest extends BaseIntTest {
         ;
     }
 
+    private void createCase(String caseId, String defendantId) {
+        var updatedJson = caseDetailsJson
+            .replace("\"caseId\": \"571b7172-4cef-435c-9048-d071a43b9dbf\"", "\"caseId\": \"" + caseId + "\"")
+            .replace("\"defendantId\": \"e0056894-e8f8-42c2-ba9a-e41250c3d1a3\"", "\"defendantId\": \"" + defendantId + "\"")
+            ;
+
+        given()
+            .auth()
+            .oauth2(getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(updatedJson)
+            .when()
+            .put(String.format(PUT_BY_CASEID_AND_DEFENDANTID_PATH, caseId, defendantId))
+            .then()
+            .statusCode(201)
+            .body("caseNo", equalTo(JSON_CASE_NO))
+            .body("crn", equalTo(CRN))
+            .body("courtCode", equalTo(COURT_CODE))
+        ;
+    }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
@@ -11,6 +11,7 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtSession;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantOffenceEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantType;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.GroupedOffenderMatchesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.NamePropertiesEntity;
@@ -272,6 +273,25 @@ class CourtCaseResponseMapperTest {
         assertThat(courtCaseResponse.getListNo()).isEqualTo(LIST_NO);
         assertThat(courtCaseResponse.getSessionStartTime()).isEqualTo(SESSION_START_TIME);
         assertThat(courtCaseResponse.getSession()).isSameAs(CourtSession.MORNING);
+    }
+
+    @Test
+    void givenMultipleDefendants_whenMapByDefendantId_thenReturnCorrectDefendant() {
+
+        var newName = NamePropertiesEntity.builder().surname("PRESLEY").forename1("Elvis").build();
+        var defendant1 = EntityHelper.aDefendantEntity("bd1f71e5-939b-4580-8354-7d6061a58032")
+            .withName(newName)
+            .withCrn("D99999");
+        var defendant2 = EntityHelper.aDefendantEntity(DEFENDANT_ID);
+
+        var courtCase = courtCaseEntity.withDefendants(List.of(defendant1, defendant2));
+
+        var response = CourtCaseResponseMapper.mapFrom(courtCase, "bd1f71e5-939b-4580-8354-7d6061a58032", 5);
+
+        assertCaseFields(response, null);
+        assertThat(response.getNumberOfPossibleMatches()).isEqualTo(5);
+        assertThat(response.getCrn()).isEqualTo("D99999");
+        assertThat(response.getName()).isEqualTo(newName);
     }
 
     private GroupedOffenderMatchesEntity buildMatchGroups() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
@@ -41,22 +41,34 @@ public class EntityHelper {
     public static final String OFFENCE_SUMMARY = "OFFENCE SUMMARY";
     public static final String OFFENCE_ACT = "OFFENCE ACT";
 
-    public static CourtCaseEntity aCourtCaseEntity(String crn) {
+    public static CourtCaseEntity aCourtCaseEntity(String caseId) {
+        return populateBasics()
+            .caseId(caseId)
+            .caseNo(CASE_NO)
+            .build();
+    }
+
+    public static CourtCaseEntity aCourtCaseEntityLinked(String crn) {
         return populateBasics()
             .crn(crn)
+            .caseId(CASE_ID)
             .caseNo(CASE_NO)
             .build();
     }
 
     public static CourtCaseEntity aCourtCaseEntity(String crn, String caseNo) {
+
         return populateBasics()
             .crn(crn)
+            .caseId(CASE_ID)
             .caseNo(caseNo)
+            .defendants(List.of(aDefendantEntity()))
             .build();
     }
 
-    public static CourtCaseEntity aCourtCaseEntity(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus) {
+    public static CourtCaseEntity aCourtCaseEntityLinked(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus) {
         return populateBasics()
+            .caseId(CASE_ID)
             .crn(crn)
             .caseNo(caseNo)
             .sessionStartTime(sessionStartTime)
@@ -64,7 +76,7 @@ public class EntityHelper {
             .build();
     }
 
-    public static CourtCaseEntity aCourtCaseEntity(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus, String caseId, String courtCode) {
+    public static CourtCaseEntity aCourtCaseEntityLinked(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus, String caseId, String courtCode) {
         return populateBasics()
             .crn(crn)
             .caseNo(caseNo)
@@ -99,6 +111,7 @@ public class EntityHelper {
             .previouslyKnownTerminationDate(TERMINATION_DATE)
             .probationStatus(PROBATION_STATUS)
             .suspendedSentenceOrder(SUSPENDED_SENTENCE)
+            .offences(List.of(aDefendantOffence()))
             .build();
     }
 
@@ -111,18 +124,31 @@ public class EntityHelper {
     }
 
     public static HearingEntity aHearingEntity() {
+        return aHearingEntity(SESSION_START_TIME);
+    }
+
+    public static HearingEntity aHearingEntity(LocalDateTime sessionStartTime) {
         return HearingEntity.builder()
             .listNo(LIST_NO)
-            .hearingDay(SESSION_START_TIME.toLocalDate())
-            .hearingTime(SESSION_START_TIME.toLocalTime())
+            .hearingDay(sessionStartTime.toLocalDate())
+            .hearingTime(sessionStartTime.toLocalTime())
             .courtRoom(COURT_ROOM)
             .courtCode(COURT_CODE)
             .build();
     }
 
+    public static OffenceEntity anOffence() {
+        return OffenceEntity.builder()
+            .offenceSummary(OFFENCE_SUMMARY)
+            .offenceTitle(OFFENCE_TITLE)
+            .act(OFFENCE_ACT)
+            .sequenceNumber(1)
+            .build();
+    }
+
     private static CourtCaseEntity.CourtCaseEntityBuilder populateBasics() {
+        var defendant = aDefendantEntity();
         return CourtCaseEntity.builder()
-            .caseId(CASE_ID)
             .courtCode(COURT_CODE)
             .courtRoom(COURT_ROOM)
             .sessionStartTime(SESSION_START_TIME)
@@ -146,17 +172,22 @@ public class EntityHelper {
             .sourceType(SOURCE)
             .deleted(false)
             .firstCreated(LocalDateTime.now())
-            .offences(List.of(anOffence()));
+            .defendants(List.of(defendant))
+            .offences(List.of(anOffence()))
+            .hearings(List.of(aHearingEntity()));
     }
 
-    private static OffenceEntity anOffence() {
-        return OffenceEntity.builder()
-            .offenceSummary(OFFENCE_SUMMARY)
-            .offenceTitle(OFFENCE_TITLE)
+    public static DefendantOffenceEntity aDefendantOffence() {
+        return aDefendantOffence(OFFENCE_TITLE, 1);
+    }
+
+    public static DefendantOffenceEntity aDefendantOffence(String title, Integer seq) {
+        return DefendantOffenceEntity.builder()
+            .summary(OFFENCE_SUMMARY)
+            .title(title)
             .act(OFFENCE_ACT)
-            .sequenceNumber(1)
+            .sequence(seq)
             .build();
     }
-
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
@@ -48,7 +48,7 @@ public class EntityHelper {
             .build();
     }
 
-    public static CourtCaseEntity aCourtCaseEntityLinked(String crn) {
+    public static CourtCaseEntity aCourtCaseEntityWithCrn(String crn) {
         return populateBasics()
             .crn(crn)
             .caseId(CASE_ID)
@@ -66,7 +66,7 @@ public class EntityHelper {
             .build();
     }
 
-    public static CourtCaseEntity aCourtCaseEntityLinked(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus) {
+    public static CourtCaseEntity aCourtCaseEntity(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus) {
         return populateBasics()
             .caseId(CASE_ID)
             .crn(crn)
@@ -76,7 +76,7 @@ public class EntityHelper {
             .build();
     }
 
-    public static CourtCaseEntity aCourtCaseEntityLinked(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus, String caseId, String courtCode) {
+    public static CourtCaseEntity aCourtCase(String crn, String caseNo, LocalDateTime sessionStartTime, String probationStatus, String caseId, String courtCode) {
         return populateBasics()
             .crn(crn)
             .caseNo(caseNo)
@@ -92,27 +92,7 @@ public class EntityHelper {
     }
 
     public static DefendantEntity aDefendantEntity(AddressPropertiesEntity address, NamePropertiesEntity name) {
-        return DefendantEntity.builder()
-            .name(name)
-            .defendantName(name.getFullName())
-            .crn(CRN)
-            .cro(CRO)
-            .pnc(PNC)
-            .type(DefendantType.PERSON)
-            .address(address)
-            .dateOfBirth(DEFENDANT_DOB)
-            .sex(DEFENDANT_SEX)
-            .nationality1(NATIONALITY_1)
-            .nationality2(NATIONALITY_2)
-            .defendantId(DEFENDANT_ID)
-            .awaitingPsr(AWAITING_PSR)
-            .breach(BREACH)
-            .preSentenceActivity(PRE_SENTENCE_ACTIVITY)
-            .previouslyKnownTerminationDate(TERMINATION_DATE)
-            .probationStatus(PROBATION_STATUS)
-            .suspendedSentenceOrder(SUSPENDED_SENTENCE)
-            .offences(List.of(aDefendantOffence()))
-            .build();
+        return aDefendantEntity(address, name, DEFENDANT_ID);
     }
 
     public static DefendantEntity aDefendantEntity(NamePropertiesEntity name) {
@@ -121,6 +101,34 @@ public class EntityHelper {
 
     public static DefendantEntity aDefendantEntity(AddressPropertiesEntity address) {
         return aDefendantEntity(address, NAME);
+    }
+
+    public static DefendantEntity aDefendantEntity(String defendantId) {
+        return aDefendantEntity(DEFENDANT_ADDRESS, NAME, defendantId);
+    }
+
+    private static DefendantEntity aDefendantEntity(AddressPropertiesEntity defendantAddress, NamePropertiesEntity name, String defendantId) {
+        return DefendantEntity.builder()
+            .name(name)
+            .defendantName(name.getFullName())
+            .crn(CRN)
+            .cro(CRO)
+            .pnc(PNC)
+            .type(DefendantType.PERSON)
+            .address(defendantAddress)
+            .dateOfBirth(DEFENDANT_DOB)
+            .sex(DEFENDANT_SEX)
+            .nationality1(NATIONALITY_1)
+            .nationality2(NATIONALITY_2)
+            .defendantId(defendantId)
+            .awaitingPsr(AWAITING_PSR)
+            .breach(BREACH)
+            .preSentenceActivity(PRE_SENTENCE_ACTIVITY)
+            .previouslyKnownTerminationDate(TERMINATION_DATE)
+            .probationStatus(PROBATION_STATUS)
+            .suspendedSentenceOrder(SUSPENDED_SENTENCE)
+            .offences(List.of(aDefendantOffence()))
+            .build();
     }
 
     public static HearingEntity aHearingEntity() {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceTest.java
@@ -4,8 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Data;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,6 +24,7 @@ import org.springframework.lang.NonNull;
 import uk.gov.justice.probation.courtcaseservice.controller.exceptions.ConflictingInputException;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.GroupedOffenderMatchesEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderMatchEntity;
@@ -31,6 +36,7 @@ import uk.gov.justice.probation.courtcaseservice.service.exceptions.EntityNotFou
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.timeout;
@@ -76,10 +82,10 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogCreatedAndLinkedEvent() {
+        void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogCreatedAndLinkedEvent() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(courtCaseRepository.findFirstByCaseNoOrderByCreatedDesc(COURT_CODE, CASE_NO)).thenReturn(Optional.empty());
-            var otherCourtCaseToUpdate = EntityHelper.aCourtCaseEntity(CRN, "999", LocalDateTime.now().plusDays(1), "Current");
+            var otherCourtCaseToUpdate = EntityHelper.aCourtCaseEntityLinked(CRN, "999", LocalDateTime.now().plusDays(1), "Current");
             when(courtCaseRepository.findOtherCurrentCasesByCrn(CRN, CASE_NO)).thenReturn(List.of(otherCourtCaseToUpdate));
             when(courtCaseRepository.save(courtCase)).thenReturn(courtCase);
 
@@ -89,13 +95,13 @@ class ImmutableCourtCaseServiceTest {
             verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.DEFENDANT_LINKED, courtCase);
             verify(courtCaseRepository).save(courtCase);
             assertThat(savedCourtCase).isNotNull();
-            var otherCourtCaseUpdated = EntityHelper.aCourtCaseEntity(CRN, "999", LocalDateTime.now().plusDays(1), PROBATION_STATUS);
+            var otherCourtCaseUpdated = EntityHelper.aCourtCaseEntityLinked(CRN, "999", LocalDateTime.now().plusDays(1), PROBATION_STATUS);
             verify(courtCaseRepository, timeout(2000)).saveAll(List.of(otherCourtCaseUpdated));
             verifyNoMoreInteractions(courtCaseRepository, telemetryService);
         }
 
         @Test
-        public void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithoutCrn_thenLogOnlyCreatedEvent() {
+        void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithoutCrn_thenLogOnlyCreatedEvent() {
             courtCase = EntityHelper.aCourtCaseEntity(null, CASE_NO);
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(courtCaseRepository.findFirstByCaseNoOrderByCreatedDesc(COURT_CODE, CASE_NO)).thenReturn(Optional.empty());
@@ -109,7 +115,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenExistingCase_whenCreateOrUpdateCaseCalled_thenLogUpdatedEvent() {
+        void givenExistingCase_whenCreateOrUpdateCaseCalled_thenLogUpdatedEvent() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(courtCaseRepository.findFirstByCaseNoOrderByCreatedDesc(COURT_CODE, CASE_NO)).thenReturn(Optional.of(courtCase));
             when(courtCaseRepository.save(courtCase)).thenReturn(courtCase);
@@ -122,7 +128,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenExistingCaseWithNullCrn_whenCreateOrUpdateCaseCalledWithCrn_thenLogLinkedEvent() {
+        void givenExistingCaseWithNullCrn_whenCreateOrUpdateCaseCalledWithCrn_thenLogLinkedEvent() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             var existingCase = EntityHelper.aCourtCaseEntity(null, CASE_NO);
             when(courtCaseRepository.findFirstByCaseNoOrderByCreatedDesc(COURT_CODE, CASE_NO)).thenReturn(Optional.of(existingCase));
@@ -138,7 +144,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenExistingCaseWithCrn_whenCreateOrUpdateCaseCalledWithNullCrn_thenLogUnLinkedEvent() {
+        void givenExistingCaseWithCrn_whenCreateOrUpdateCaseCalledWithNullCrn_thenLogUnLinkedEvent() {
 
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(courtCaseRepository.findFirstByCaseNoOrderByCreatedDesc(COURT_CODE, CASE_NO)).thenReturn(Optional.of(courtCase));
@@ -158,7 +164,182 @@ class ImmutableCourtCaseServiceTest {
 
     @ExtendWith(MockitoExtension.class)
     @Nested
-    @DisplayName("Tests for createCase by case ID")
+    @DisplayName("Tests for createCase by case ID and defendant ID")
+    class CreateUpdateByCaseAndDefendantIdTest {
+
+        private CourtCaseEntity incomingCourtCase;
+        private DefendantEntity defendant;
+
+        @BeforeEach
+        void setup() {
+            service = new ImmutableCourtCaseService(courtRepository, courtCaseRepository, telemetryService, groupedOffenderMatchRepository, false);
+            lenient().when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
+            incomingCourtCase = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
+            defendant = DefendantEntity.builder().defendantId(DEFENDANT_ID).build();
+        }
+
+        @Test
+        void givenUnknownCourtCode_whenCreateOrUpdateCase_thenThrowException() {
+            when(courtRepository.findByCourtCode("XXX")).thenThrow(new EntityNotFoundException("not found court"));
+            incomingCourtCase = CourtCaseEntity.builder()
+                .courtCode("XXX")
+                .caseId(CASE_ID)
+                .build();
+
+            Assertions.assertThrows(EntityNotFoundException.class, () -> {
+                service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, incomingCourtCase).block();
+            });
+            verify(courtRepository).findByCourtCode("XXX");
+            verifyNoMoreInteractions(courtRepository, courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void givenCaseIdMismatch_whenCreateOrUpdateCase_thenThrowException() {
+            incomingCourtCase = EntityHelper.aCourtCaseEntityLinked(CRN);
+            Assertions.assertThrows(ConflictingInputException.class, () -> {
+                service.createUpdateCaseForSingleDefendantId("OTHER-CASE-ID", DEFENDANT_ID, incomingCourtCase).block();
+            });
+            verify(courtRepository).findByCourtCode(COURT_CODE);
+            verifyNoMoreInteractions(courtRepository, courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void givenDefendantIdMismatch_whenCreateOrUpdateCase_thenThrowException() {
+            Assertions.assertThrows(ConflictingInputException.class, () -> {
+                service.createUpdateCaseForSingleDefendantId(CASE_ID, "OTHER-DEFENDANT-ID", incomingCourtCase).block();
+            });
+            verify(courtRepository).findByCourtCode(COURT_CODE);
+            verifyNoMoreInteractions(courtRepository, courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void givenSingleNewLinkedCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogUpdatedEventAndSave() {
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.empty());
+            when(courtCaseRepository.save(incomingCourtCase)).thenReturn(incomingCourtCase);
+            when(courtCaseRepository.findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID)).thenReturn(Collections.emptyList());
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, incomingCourtCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.COURT_CASE_CREATED, incomingCourtCase);
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.DEFENDANT_LINKED, incomingCourtCase);
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).save(incomingCourtCase);
+            verify(courtCaseRepository).findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID);
+            assertThat(savedCourtCase).isSameAs(incomingCourtCase);
+
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService, groupedOffenderMatchRepository);
+        }
+
+        @Test
+        void givenSingleNewUnlinkedCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogUpdatedEventAndSave() {
+            incomingCourtCase = EntityHelper.aCourtCaseEntity(CASE_ID);
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.empty());
+            when(courtCaseRepository.save(incomingCourtCase)).thenReturn(incomingCourtCase);
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, incomingCourtCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.COURT_CASE_CREATED, incomingCourtCase);
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).save(incomingCourtCase);
+            assertThat(savedCourtCase).isSameAs(incomingCourtCase);
+
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService, groupedOffenderMatchRepository);
+        }
+
+        @Test
+        void givenSingleExistingCaseLinkedCase_whenCreateOrUpdateCaseCalledWithoutCrnToUnlink_thenLogUpdatedEventAndSave() {
+            var updatedCase = EntityHelper.aCourtCaseEntity(CASE_ID).withCourtRoom("02").withDefendants(List.of(defendant));
+            var existingCase = EntityHelper.aCourtCaseEntityLinked(CRN);
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.of(existingCase));
+            when(courtCaseRepository.save(updatedCase)).thenReturn(updatedCase);
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, updatedCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.COURT_CASE_UPDATED, updatedCase);
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.DEFENDANT_UNLINKED, existingCase);
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).save(updatedCase);
+            assertThat(savedCourtCase).isSameAs(updatedCase);
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void givenSingleExistingLinkedCase_whenCreateOrUpdateCaseCalledWithoutCrn_thenLogUpdatedEventAndSave() {
+            var updatedCase = EntityHelper.aCourtCaseEntity(CASE_ID).withCourtRoom("02").withDefendants(List.of(defendant)).withCrn(CRN);
+            var existingCase = EntityHelper.aCourtCaseEntity(CASE_ID);
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.of(existingCase));
+            when(courtCaseRepository.findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID)).thenReturn(Collections.emptyList());
+            when(courtCaseRepository.save(updatedCase)).thenReturn(updatedCase);
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, updatedCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.COURT_CASE_UPDATED, updatedCase);
+            verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.DEFENDANT_LINKED, updatedCase);
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID);
+            verify(courtCaseRepository).save(updatedCase);
+            assertThat(savedCourtCase).isSameAs(updatedCase);
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void givenExistingCaseWithMultipleDefendants_whenCreateOrUpdateCaseCalledWithCrn_thenLogCreatedAndLinkedEvent() {
+            var otherExistingDefendant = DefendantEntity.builder().defendantId("DEF_ID_2").crn("X99999").build();
+            var updatedCase = EntityHelper.aCourtCaseEntity(CASE_ID).withDefendants(List.of(defendant));
+            var existingCase = EntityHelper.aCourtCaseEntity(CASE_ID).withDefendants(List.of(defendant, otherExistingDefendant));
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.of(existingCase));
+            var expectedSave = new CourtCaseEntityMatcher(CASE_ID, List.of(DEFENDANT_ID, "DEF_ID_2"));
+            when(courtCaseRepository.save(argThat(expectedSave))).thenReturn(updatedCase);
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, updatedCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(eq(TelemetryEventType.COURT_CASE_UPDATED), eq(updatedCase));
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).save(argThat(expectedSave));
+            assertThat(savedCourtCase).isNotNull();
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService);
+        }
+
+        @Test
+        void whenAddDefendants_thenReturn() {
+            var otherExistingDefendant = DefendantEntity.builder().defendantId("DEF_ID_2").crn("X99999").build();
+            var updatedCase = EntityHelper.aCourtCaseEntity(CASE_ID).withDefendants(List.of(defendant));
+            var existingCase = EntityHelper.aCourtCaseEntity(CASE_ID).withDefendants(List.of(defendant, otherExistingDefendant));
+
+            when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.of(existingCase));
+            var expectedSave = new CourtCaseEntityMatcher(CASE_ID, List.of(DEFENDANT_ID, "DEF_ID_2"));
+            when(courtCaseRepository.save(argThat(expectedSave))).thenReturn(updatedCase);
+
+            var savedCourtCase = service.createUpdateCaseForSingleDefendantId(CASE_ID, DEFENDANT_ID, updatedCase).block();
+
+            verify(telemetryService).trackCourtCaseEvent(eq(TelemetryEventType.COURT_CASE_UPDATED), eq(updatedCase));
+            verify(courtCaseRepository).findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
+            verify(courtCaseRepository).save(argThat(expectedSave));
+            assertThat(savedCourtCase).isNotNull();
+            verifyNoMoreInteractions(courtCaseRepository, telemetryService);
+        }
+
+        @Data
+        class CourtCaseEntityMatcher implements ArgumentMatcher<CourtCaseEntity> {
+
+            private final String caseId;
+            private final List<String> defendantIds;
+
+            @Override
+            public boolean matches(CourtCaseEntity arg) {
+                final var argDefendantIds = Optional.ofNullable(arg.getDefendants()).orElse(Collections.emptyList())
+                    .stream()
+                    .map(DefendantEntity::getDefendantId)
+                    .collect(Collectors.toList());
+                return caseId.equals(arg.getCaseId()) && defendantIds.equals(argDefendantIds);
+            }
+        }
+
+    }
+
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    @DisplayName("Tests for createCase by case ID with ExtendedCourtCaseRequest")
     class CreateUpdateByCaseIdTest {
 
         private CourtCaseEntity courtCase;
@@ -172,7 +353,7 @@ class ImmutableCourtCaseServiceTest {
 
         @Test
         public void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogCreatedAndLinkedEvent() {
-            var otherCourtCaseToUpdate = EntityHelper.aCourtCaseEntity(CRN, "999", LocalDateTime.now().plusDays(1), "Current");
+            var otherCourtCaseToUpdate = EntityHelper.aCourtCaseEntityLinked(CRN, "999", LocalDateTime.now().plusDays(1), "Current");
             when(courtCaseRepository.findFirstByCaseIdOrderByIdDesc(CASE_ID)).thenReturn(Optional.empty());
             when(courtCaseRepository.findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID)).thenReturn(List.of(otherCourtCaseToUpdate));
             when(courtCaseRepository.save(courtCase)).thenReturn(courtCase);
@@ -183,7 +364,7 @@ class ImmutableCourtCaseServiceTest {
             verify(telemetryService).trackCourtCaseEvent(TelemetryEventType.DEFENDANT_LINKED, courtCase);
             verify(courtCaseRepository).save(courtCase);
             assertThat(savedCourtCase).isNotNull();
-            var otherCourtCaseUpdated = EntityHelper.aCourtCaseEntity(CRN, "999", LocalDateTime.now().plusDays(1), PROBATION_STATUS);
+            var otherCourtCaseUpdated = EntityHelper.aCourtCaseEntityLinked(CRN, "999", LocalDateTime.now().plusDays(1), PROBATION_STATUS);
             verify(courtCaseRepository, timeout(2000)).saveAll(List.of(otherCourtCaseUpdated));
             verifyNoMoreInteractions(courtCaseRepository, telemetryService);
         }
@@ -417,7 +598,7 @@ class ImmutableCourtCaseServiceTest {
 
         @Test
         void givenExistingCaseId_getCourtCaseByCaseId_thenRetrieve() {
-            var caseEntityFromRepo = EntityHelper.aCourtCaseEntity(CRN);
+            var caseEntityFromRepo = EntityHelper.aCourtCaseEntityLinked(CRN);
             when(courtCaseRepository.findByCaseId(CASE_ID)).thenReturn(Optional.of(caseEntityFromRepo));
 
             var caseEntity = service.getCaseByCaseId(CASE_ID);
@@ -438,7 +619,7 @@ class ImmutableCourtCaseServiceTest {
 
         @Test
         void whenGetCourtCaseByIdAndDefendantId_shouldRetrieveCaseFromRepository() {
-            final var courtCaseEntity = EntityHelper.aCourtCaseEntity(CRN);
+            final var courtCaseEntity = EntityHelper.aCourtCaseEntityLinked(CRN);
             when(courtCaseRepository.findByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID)).thenReturn(Optional.of(courtCaseEntity));
 
             final var entity = service.getCaseByCaseIdAndDefendantId(CASE_ID, DEFENDANT_ID);
@@ -458,7 +639,6 @@ class ImmutableCourtCaseServiceTest {
             assertThat(exception).isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Case " + CASE_ID + " not found for defendant " + DEFENDANT_ID);
         }
-
     }
 
     @ExtendWith(MockitoExtension.class)
@@ -495,7 +675,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenOffenderMatchesExistForCase_whenCrnUpdated_thenUpdateMatches() {
+        void givenOffenderMatchesExistForCase_whenCrnUpdated_thenUpdateMatches() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             var existingCase = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
             when(groupedOffenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(buildOffenderMatches());
@@ -522,7 +702,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenOffenderMatchesExistForCase_whenCrnRemoved_thenRejectAllMatches() {
+        void givenOffenderMatchesExistForCase_whenCrnRemoved_thenRejectAllMatches() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(groupedOffenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(buildOffenderMatches());
             var caseToUpdate = EntityHelper.aCourtCaseEntity(null, CASE_NO);
@@ -550,7 +730,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void whenUpdateMatches_thenLogRejectedAndConfirmedEvents() {
+        void whenUpdateMatches_thenLogRejectedAndConfirmedEvents() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             var caseToUpdate = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
             var existingCase = EntityHelper.aCourtCaseEntity(null, CASE_NO);
@@ -573,7 +753,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenMatchesDontExistForCase_whenCrnUpdated_thenDontThrowException() {
+        void givenMatchesDontExistForCase_whenCrnUpdated_thenDontThrowException() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             var caseToUpdate = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
 
@@ -584,7 +764,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenMatchesAreNullForCase_whenCrnUpdated_thenDontThrowException() {
+        void givenMatchesAreNullForCase_whenCrnUpdated_thenDontThrowException() {
             when(courtRepository.findByCourtCode(COURT_CODE)).thenReturn(Optional.of(courtEntity));
             when(groupedOffenderMatchRepository.findByCourtCodeAndCaseNo(COURT_CODE, CASE_NO)).thenReturn(Optional.empty());
             var caseToUpdate = EntityHelper.aCourtCaseEntity(CRN, CASE_NO);
@@ -595,7 +775,7 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @NonNull
-        public Optional<GroupedOffenderMatchesEntity> buildOffenderMatches() {
+        private Optional<GroupedOffenderMatchesEntity> buildOffenderMatches() {
             return Optional.ofNullable(GroupedOffenderMatchesEntity.builder()
                 .courtCode(COURT_CODE)
                 .caseNo(CASE_NO)
@@ -615,8 +795,8 @@ class ImmutableCourtCaseServiceTest {
 
     @ExtendWith(MockitoExtension.class)
     @Nested
-    @DisplayName("Tests for updateStatus")
-    class PostUpdateStatusTest {
+    @DisplayName("Tests for updateOtherProbationStatusForCrn")
+    class PostUpdateProbationStatusStatusTest {
 
         @BeforeEach
         void setup() {
@@ -624,18 +804,50 @@ class ImmutableCourtCaseServiceTest {
         }
 
         @Test
-        public void givenNoExistingCase_whenCreateOrUpdateCaseCalledWithCrn_thenLogCreatedAndLinkedEvent() {
+        public void givenNullCrn_whenUpdateOtherProbationStatusForCrn_thenDoNothing() {
+
+            service.updateOtherProbationStatusForCrn(null, "Current", CASE_NO);
+
+            verifyNoMoreInteractions(courtCaseRepository);
+        }
+
+        @Test
+        public void givenNoExistingCase_whenUpdateOtherProbationStatusForCrnWithCrn_thenUpdateAndSaveAll() {
 
             var now = LocalDateTime.now();
-            var courtCaseToIgnore = EntityHelper.aCourtCaseEntity(CRN, "1235", now.plusDays(1), "Current");
-            var courtCaseToUpdate = EntityHelper.aCourtCaseEntity(CRN, "1236", now.plusDays(1), "Previously known");
-
+            // One will be ignored because the status is the same
+            var courtCaseToIgnore = EntityHelper.aCourtCaseEntityLinked(CRN, "1235", now.plusDays(1), "Current");
+            var courtCaseToUpdate = EntityHelper.aCourtCaseEntityLinked(CRN, "1236", now.plusDays(1), "Previously known");
             when(courtCaseRepository.findOtherCurrentCasesByCrn(CRN, CASE_NO)).thenReturn(List.of(courtCaseToIgnore, courtCaseToUpdate));
 
             service.updateOtherProbationStatusForCrn(CRN, "Current", CASE_NO);
 
             // The case to be saved will be same as the updated with case no 1236 but with Current as the
-            var expectedCourtCaseToSave = EntityHelper.aCourtCaseEntity(CRN, "1236", now.plusDays(1), "Current");
+            var expectedCourtCaseToSave = EntityHelper.aCourtCaseEntityLinked(CRN, "1236", now.plusDays(1), "Current");
+            verify(courtCaseRepository).saveAll(List.of(expectedCourtCaseToSave));
+        }
+
+        @Test
+        public void givenNullCrn_whenUpdateOtherProbationStatusForCaseId_thenDoNothing() {
+
+            service.updateOtherProbationStatusForCrnByCaseId(null, "Current", CASE_NO);
+
+            verifyNoMoreInteractions(courtCaseRepository);
+        }
+
+        @Test
+        public void givenNoExistingCase_whenUpdateOtherProbationStatusForCaseIdWithCrn_thenUpdateAndSaveAll() {
+
+            var now = LocalDateTime.now();
+            // One will be ignored because the status is the same
+            var courtCaseToIgnore = EntityHelper.aCourtCaseEntityLinked(CRN, "1235", now.plusDays(1), "Current");
+            var courtCaseToUpdate = EntityHelper.aCourtCaseEntityLinked(CRN, "1236", now.plusDays(1), "Previously known");
+            when(courtCaseRepository.findOtherCurrentCasesByCrnNotCaseId(CRN, CASE_ID)).thenReturn(List.of(courtCaseToIgnore, courtCaseToUpdate));
+
+            service.updateOtherProbationStatusForCrnByCaseId(CRN, "Current", CASE_ID);
+
+            // The case to be saved will be same as the updated with case no 1236 but with Current as the
+            var expectedCourtCaseToSave = EntityHelper.aCourtCaseEntityLinked(CRN, "1236", now.plusDays(1), "Current");
             verify(courtCaseRepository).saveAll(List.of(expectedCourtCaseToSave));
         }
     }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/CourtCaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/CourtCaseMapperTest.java
@@ -178,6 +178,14 @@ class CourtCaseMapperTest {
                 assertThat(defendant.getName().getForename1()).isEqualTo("Una");
                 assertThat(defendant.getCourtCase()).isSameAs(newEntity);
             });
+        assertThat(newEntity.getDefendants()).filteredOn(d -> d.getCrn().equals("X340906"))
+            .allSatisfy(defendant -> {
+                assertThat(defendant.getName().getSurname()).isEqualTo("BENNETT");
+                assertThat(defendant.getName().getForename1()).isEqualTo("Gordon");
+                assertThat(defendant.getCourtCase()).isSameAs(newEntity);
+                var offences = defendant.getOffences();
+                assertThat(offences.get(0).getDefendant()).isSameAs(defendant);
+            });
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/CourtCaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/mapper/CourtCaseMapperTest.java
@@ -1,33 +1,220 @@
 package uk.gov.justice.probation.courtcaseservice.service.mapper;
 
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.BaseImmutableEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.NamePropertiesEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CASE_ID;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CASE_NO;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.COURT_CODE;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.COURT_ROOM;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.CRN;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_ADDRESS;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_ID;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.OFFENCE_SUMMARY;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.OFFENCE_TITLE;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.SESSION_START_TIME;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.SOURCE;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.aHearingEntity;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.anOffence;
 
 class CourtCaseMapperTest {
 
     @Test
-    public void givenSimpleEntity_whenCreateNewThenChangeProbationStatus() {
+    void givenUpdateForSameCrn_whenCreateNewCourtCase_thenChangeProbationStatus() {
 
-        var existingCourtCase = EntityHelper.aCourtCaseEntity(CRN);
+        var defendantEntity1 = EntityHelper.aDefendantEntity();
+        var defendantEntity2 = DefendantEntity.builder().crn("X99999").probationStatus(null).build();
+        var existingCourtCase = CourtCaseEntity.builder().caseId(CASE_ID)
+            .caseNo(CASE_NO)
+            .courtCode(COURT_CODE)
+            .sourceType(SOURCE)
+            .defendants(List.of(defendantEntity1, defendantEntity2))
+            .offences(List.of(EntityHelper.anOffence()))
+            .hearings(List.of(EntityHelper.aHearingEntity(), EntityHelper.aHearingEntity(SESSION_START_TIME.plusMinutes(120))))
+            .build();
 
-        var newEntity = CourtCaseMapper.create(existingCourtCase, "Current");
+        var newEntity = CourtCaseMapper.create(existingCourtCase, CRN, "CURRENT");
 
         assertNotSame(newEntity, existingCourtCase);
-        assertThat(newEntity.getProbationStatus()).isEqualTo("Current");
+        assertThat(newEntity.getDefendants()).hasSize(2);
+        assertThat(newEntity.getProbationStatus()).isEqualTo("CURRENT");
         assertThat(newEntity.getSourceType()).isEqualTo(SOURCE);
         assertThat(newEntity.getCourtCode()).isEqualTo(COURT_CODE);
         assertThat(newEntity.getOffences()).hasSize(1);
+        assertThat(newEntity.getHearings()).hasSize(2);
 
-        var newOffence = newEntity.getOffences().get(0);
-        assertThat(newOffence.getOffenceTitle()).isEqualTo(OFFENCE_TITLE);
-        assertThat(newOffence.getCourtCase()).isSameAs(newEntity);
+        newEntity.getDefendants()
+            .stream()
+            .filter(defendantEntity -> defendantEntity.getCrn().equals(CRN))
+            .findFirst()
+            .ifPresentOrElse((entity) -> assertThat(entity.getProbationStatus()).isEqualTo("CURRENT"), Assertions::fail);
+        // The other defendant is untouched
+        newEntity.getDefendants()
+            .stream()
+            .filter(defendantEntity -> defendantEntity.getCrn().equals("X99999"))
+            .findFirst()
+            .ifPresentOrElse((entity) -> assertThat(entity.getProbationStatus()).isNull(), Assertions::fail);
     }
 
+    @Test
+    void givenUpdateForOtherCrn_whenCreateDefendant_thenPopulateAllFieldsLeaveCrn() {
+
+        var defendant = EntityHelper.aDefendantEntity();
+
+        var newEntity = CourtCaseMapper.createDefendant(defendant, "OTHER_CRN", "CURRENT");
+
+        assertThat(newEntity).isNotSameAs(defendant);
+        assertThat(newEntity.getProbationStatus()).isNotEqualTo("CURRENT");
+        assertThat(newEntity.getDefendantId()).isEqualTo(defendant.getDefendantId());
+        assertThat(newEntity.getId()).isNull();
+        assertThat(newEntity.getOffences()).hasSize(1);
+        assertThat(newEntity.getDefendantName()).isEqualTo(defendant.getDefendantName());
+        assertThat(newEntity.getName()).isEqualTo(defendant.getName());
+        assertThat(newEntity.getDefendantId()).isEqualTo(defendant.getDefendantId());
+        assertThat(newEntity.getType()).isEqualTo(defendant.getType());
+        assertThat(newEntity.getAddress()).isEqualTo(defendant.getAddress());
+        assertThat(newEntity.getCrn()).isEqualTo(defendant.getCrn());
+        assertThat(newEntity.getPnc()).isEqualTo(defendant.getPnc());
+        assertThat(newEntity.getCro()).isEqualTo(defendant.getCro());
+        assertThat(newEntity.getDateOfBirth()).isEqualTo(defendant.getDateOfBirth());
+        assertThat(newEntity.getSex()).isEqualTo(defendant.getSex());
+        assertThat(newEntity.getNationality1()).isEqualTo(defendant.getNationality1());
+        assertThat(newEntity.getNationality2()).isEqualTo(defendant.getNationality2());
+        assertThat(newEntity.getPreviouslyKnownTerminationDate()).isEqualTo(defendant.getPreviouslyKnownTerminationDate());
+        assertThat(newEntity.getSuspendedSentenceOrder()).isEqualTo(defendant.getSuspendedSentenceOrder());
+        assertThat(newEntity.getBreach()).isEqualTo(defendant.getBreach());
+        assertThat(newEntity.getPreSentenceActivity()).isEqualTo(defendant.getPreSentenceActivity());
+        assertThat(newEntity.getAwaitingPsr()).isEqualTo(defendant.getAwaitingPsr());
+        assertThat(newEntity.isManualUpdate()).isEqualTo(defendant.isManualUpdate());
+    }
+
+    @Test
+    void givenUpdateForSameCrn_whenCreateNew_thenPopulateAllFieldsAndUpdateProbationStatus() {
+
+        var defendant = EntityHelper.aDefendantEntity();
+
+        var newEntity = CourtCaseMapper.createDefendant(defendant, CRN, "CURRENT");
+
+        assertThat(newEntity).isNotSameAs(defendant);
+        assertThat(newEntity.getProbationStatus()).isEqualTo("CURRENT");
+    }
+
+    @Test
+    void whenCreateDefendantOffence_thenReturnNew() {
+
+        var offence = EntityHelper.aDefendantOffence();
+
+        var newEntity = CourtCaseMapper.createDefendantOffence(offence);
+
+        assertThat(newEntity).isNotSameAs(offence);
+        assertThat(newEntity.getId()).isNull();
+        assertThat(newEntity.getTitle()).isEqualTo(OFFENCE_TITLE);
+        assertThat(newEntity.getSummary()).isEqualTo(OFFENCE_SUMMARY);
+        assertThat(newEntity.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    void whenCreateHearings_thenReturnList() {
+
+        var hearingEntity1 = EntityHelper.aHearingEntity();
+        var hearingEntity2 = EntityHelper.aHearingEntity(SESSION_START_TIME.plusDays(1));
+
+        var hearings = CourtCaseMapper.createHearings(List.of(hearingEntity1, hearingEntity2));
+
+        assertThat(hearings).hasSize(2);
+        assertThat(hearings.get(0)).isNotSameAs(hearingEntity1);
+        assertThat(hearings.get(1)).isNotSameAs(hearingEntity2);
+        assertThat(hearings).extracting("id").allMatch(Objects::isNull);
+        assertThat(hearings).extracting("courtRoom").containsOnly(COURT_ROOM);
+    }
+
+    @Test
+    void givenNullInput_whenCreateHearings_thenReturnEmptyList() {
+        assertThat(CourtCaseMapper.createHearings(null)).isEmpty();
+    }
+
+    @Test
+    void whenMerge_thenRestoreDefendantsAndHearings() {
+
+        // Update comes in with a new CRN and name
+        var newName = NamePropertiesEntity.builder().surname("STUBBS").forename1("Una").build();
+        var updatedDefendant = EntityHelper.aDefendantEntity(DEFENDANT_ADDRESS, newName)
+            .withCrn("D99999");
+        var updatedEntity = CourtCaseEntity.builder().courtCode("B33HU")
+            .defendants(List.of(updatedDefendant))
+            .offences(List.of(anOffence(), anOffence()))
+            .caseId(CASE_ID)
+            .build();
+
+        // Existing has defendants and hearings, all with ids which must be removed
+        var existingNonUpdatedDefendant = EntityHelper.aDefendantEntity()
+            .withDefendantId("904aeafa-b3db-41be-99ba-b2fbbf344d8b")
+            .withId(100L);
+        var existingUpdatedDefendant = EntityHelper.aDefendantEntity()
+            .withId(101L);
+        var existingCourtCaseEntity = EntityHelper.aCourtCaseEntity(CASE_ID)
+            .withDefendants(List.of(existingUpdatedDefendant, existingNonUpdatedDefendant))
+            .withHearings(List.of(aHearingEntity().withId(100L), aHearingEntity(SESSION_START_TIME.plusDays(1)).withId(101L)));
+
+        var newEntity = CourtCaseMapper.mergeDefendantsOnCase(existingCourtCaseEntity, updatedEntity, DEFENDANT_ID);
+
+        checkCollection(newEntity.getHearings(), newEntity);
+        checkCollection(newEntity.getOffences(), newEntity);
+        checkCollection(newEntity.getDefendants(), newEntity);
+
+        assertThat(newEntity.getDefendants()).extracting("crn").containsExactlyInAnyOrder("D99999", CRN);
+        assertThat(newEntity.getDefendants()).filteredOn(d -> d.getCrn().equals("D99999"))
+            .allSatisfy(defendant -> {
+                assertThat(defendant.getName().getSurname()).isEqualTo("STUBBS");
+                assertThat(defendant.getName().getForename1()).isEqualTo("Una");
+                assertThat(defendant.getCourtCase()).isSameAs(newEntity);
+            });
+    }
+
+    @Test
+    void givenExistingCaseWithSingleDefendant_whenMerge_thenRestoreHearings() {
+
+        // Update comes in with a new CRN and name and one hearing
+        var newName = NamePropertiesEntity.builder().surname("STUBBS").forename1("Una").build();
+        var updatedDefendant = EntityHelper.aDefendantEntity(DEFENDANT_ADDRESS, newName)
+            .withCrn("D99999");
+        var updatedEntity = CourtCaseEntity.builder().courtCode("B33HU")
+            .defendants(List.of(updatedDefendant))
+            .offences(List.of(anOffence(), anOffence()))
+            .caseId(CASE_ID)
+            .build();
+
+        // Existing has defendants and hearings, all with ids which must be removed
+        var existingUpdatedDefendant = EntityHelper.aDefendantEntity()
+            .withId(101L);
+        var existingCourtCaseEntity = EntityHelper.aCourtCaseEntity(CASE_ID)
+            .withDefendants(List.of(existingUpdatedDefendant))
+            .withHearings(List.of(aHearingEntity().withId(100L), aHearingEntity(SESSION_START_TIME.plusDays(1)).withId(101L)));
+
+        var newEntity = CourtCaseMapper.mergeDefendantsOnCase(existingCourtCaseEntity, updatedEntity, DEFENDANT_ID);
+
+        checkCollection(newEntity.getHearings(), newEntity);
+        checkCollection(newEntity.getOffences(), newEntity);
+
+        assertThat(newEntity.getDefendants()).hasSize(1);
+        assertThat(newEntity.getDefendants()).extracting("crn").containsExactly("D99999");
+        assertThat(newEntity.getDefendants().get(0).getName().getForename1()).isEqualTo("Una");
+        assertThat(newEntity.getDefendants().get(0).getName().getSurname()).isEqualTo("STUBBS");
+        assertThat(newEntity.getDefendants().get(0).getCourtCase()).isSameAs(newEntity);
+    }
+
+    private void checkCollection(List<? extends BaseImmutableEntity> childEntities, CourtCaseEntity courtCase) {
+        assertThat(childEntities).hasSize(2);
+        assertThat(childEntities).extracting("id").allMatch(Objects::isNull);
+        assertThat(childEntities).extracting("courtCase").containsExactlyInAnyOrder(courtCase, courtCase);
+    }
 }

--- a/src/test/resources/before-test.sql
+++ b/src/test/resources/before-test.sql
@@ -89,9 +89,12 @@ VALUES (-1700028908, -1700028908, 'B10JQ', 2, '2019-12-14', '13:00:00', '3rd', n
 
 -- See GET_cases_givenCreatedBefore_andCreatedAfterFilterParams_andManualUpdatesHaveBeenMadeAfterTheseTimes_whenGetCases_thenReturnManualUpdates
 INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, created_by, manual_update, source_type)
-VALUES (-1700028909, '1f93aa0a-7e46-4885-a1cb-f25a4be33a60', 1600028919, 'B30NY', 1, '2019-12-14 12:59:59', 'NO_RECORD', 'X320654', 'Hubert Farnsworth', '2020-10-01 16:59:59', 'TURANGALEE(prepare-a-case-for-court)', true, 'COMMON_PLATFORM');
+VALUES (-1700028909, 'e652eaae-1114-4593-8f56-659eb2baffcf', 1600028919, 'B30NY', 1, '2200-12-14 12:59:59', 'NO_RECORD', 'X320654', 'Hubert Farnsworth', '2020-10-01 16:59:59', 'TURANGALEE(prepare-a-case-for-court)', true, 'COMMON_PLATFORM');
 INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no, created)
-VALUES (-1700028909, -1700028909, 'B30NY', 1, '2019-12-14', '12:59:59', '3rd', '2020-10-01 16:59:59');
+VALUES (-1700028909, -1700028909, 'B30NY', 1, '2200-12-14', '12:59:59', '3rd', '2020-10-01 16:59:59');
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, DEFENDANT_ID, defendant_name, name, address, type, date_of_birth, pnc, sex, probation_status, crn)
+VALUES (-1700028909, -1700028909, 'c15475ce-9748-4a60-b42b-02ce78523c95', 'Mr Roger HUNT', '{"title": "Mr", "surname": "HUNT", "forename1": "Roger"}', '{"line1": "Anfield", "line2": "Walton Breck Road", "postcode": "L5 2DE 5dr"}', 'PERSON', '1940-05-01', 'A/1234560BA', 'M', 'NO_RECORD', 'X320654');
+
 
 -- These records are used to test the Last-Modified header CHECKED
 INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, crn, defendant_name, created, deleted, source_type)
@@ -219,3 +222,34 @@ VALUES (-2000000, -1700030001, 'd49323c0-04da-11ec-b2d8-0242ac130002', 'Mr Johnn
 
 INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
 VALUES (-2000000, -2000000, 'Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+
+-- For Single case and defendant ID save (3db9d70b-10a2-49d1-b74d-379f2db74862)
+-- 2 hearings, 2 defendants
+-- 1263de26-4a81-42d3-a798-bad802433318 - John Peel
+-- 6f014c2e-8be3-4a12-a551-8377bd31a7b8 - Jessica Peel
+INSERT INTO courtcaseservicetest.court_case (id, case_id, case_no, court_code, court_room, session_start_time, probation_status, previously_known_termination_date, suspended_sentence_order, breach, pre_sentence_activity, defendant_name, name, defendant_address, crn, pnc, cro, list_no, defendant_dob, defendant_sex, nationality_1, nationality_2, created, awaiting_psr, source_type)
+VALUES (-1800028900, '3db9d70b-10a2-49d1-b74d-379f2db74862', 1800028900, 'B33HU', 1, '2019-12-14 09:00', null, '2010-01-01', true, true, true, 'Mr John PEEL', '{"title": "Mr", "surname": "PEEL", "forename1": "John", "forename2": "Jonny", "forename3": "Jon"}','{"line1": "10", "line2": "Margrave", "postcode": "SU11 1AA", "line3": "Suffolk", "line4": null, "line5": null}', null, 'A/1234560YY', '888888/13E', '3rd', '1939-10-10', 'M', 'British', 'Irish' , now(), true, 'COMMON_PLATFORM');
+
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-3000000, -1800028900, 'B33HU', 1, '2019-12-14', '09:00', '3rd');
+INSERT INTO courtcaseservicetest.HEARING (id, court_case_id, court_code, court_room, hearing_day, hearing_time, list_no)
+VALUES (-3000001, -1800028900, 'B33HU', 1, '2019-12-15', '13:00', '3rd');
+
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, DEFENDANT_ID, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2, awaiting_psr, probation_status)
+VALUES (-3000000, -1800028900, '1263de26-4a81-42d3-a798-bad802433318', 'Mr John PEEL', '{"title": "Mr", "surname": "PEEL", "forename1": "John", "forename2": "Jonny", "forename3": "Jon"}', '{"line1": "10", "line2": "Margrave", "postcode": "SU11 1AA", "line3": "Suffolk", "line4": null, "line5": null}', 'PERSON', '1939-10-10', null, 'A/1234560YY', '888888/13E', 'M', 'British', 'Irish', true, null);
+INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
+VALUES (-3000000, -3000000, 'John PEEL Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+
+INSERT INTO courtcaseservicetest.DEFENDANT (id, court_case_id, DEFENDANT_ID, defendant_name, name, address, type, date_of_birth, crn, pnc, cro, sex, nationality_1, nationality_2, awaiting_psr)
+VALUES (-3000001, -1800028900, '6f014c2e-8be3-4a12-a551-8377bd31a7b8', 'Mrs Jessica PEEL', '{"title": "Mr", "surname": "PEEL", "forename1": "Jessica", "forename2": "Lisa", "forename3": "Julie"}', '{"line1": "11", "line2": "Margrave", "postcode": "SU11 1AA", "line3": "Suffolk", "line4": null, "line5": null}', 'PERSON', '1939-10-10', null, 'A/1234560ZZ', '999999/13E', 'F', 'British', 'Irish', true);
+INSERT INTO courtcaseservicetest.DEFENDANT_OFFENCE (ID, DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE)
+VALUES (-3000001, -3000001, 'Jessica PEEL Theft from a shop', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1);
+
+-- Two matches for Mr John PEEL
+INSERT INTO courtcaseservicetest.offender_match_group(ID, CASE_NO, COURT_CODE, CASE_ID, DEFENDANT_ID)
+VALUES (-1800028900, '1800028900', 'B33HU', '3db9d70b-10a2-49d1-b74d-379f2db74862', '1263de26-4a81-42d3-a798-bad802433318');
+INSERT INTO courtcaseservicetest.offender_match(CONFIRMED, REJECTED, CRN, MATCH_TYPE, PNC, GROUP_ID)
+VALUES (false, false, 'X320654', 'NAME_DOB', 'A323456', -1800028900);
+INSERT INTO courtcaseservicetest.offender_match(CONFIRMED, REJECTED, CRN, MATCH_TYPE, PNC, GROUP_ID)
+VALUES (false, false, 'X999999', 'NAME_DOB', 'B323456', -1800028900);
+--

--- a/src/test/resources/integration/request/PUT_courtCase_success.json
+++ b/src/test/resources/integration/request/PUT_courtCase_success.json
@@ -1,7 +1,7 @@
 {
   "courtCode": "B10JQ",
   "caseNo": "1700028914",
-  "caseId": "654321",
+  "caseId": "571b7172-4cef-435c-9048-d071a43b9dbf",
   "crn": "X320741",
   "pnc": "A/1234560BA",
   "cro": "99999",
@@ -26,6 +26,7 @@
       "act": "Contrary to section 1(1) and 7 of the Theft Act 1968."
     }
   ],
+  "defendantId": "e0056894-e8f8-42c2-ba9a-e41250c3d1a3",
   "defendantName": "Mr Dylan Adam ARMSTRONG",
   "name": {
     "title": "Mr",


### PR DESCRIPTION
Also part of this change is the fix whereby the update on probation status for other future cases for the same CRN was not saving hearings, defendants and defendant offences.

Removed the custom equals and hashCode implementations on CourtCaseEntity.