### PR TITLE
✨ PIC-1753 - repeatable migration for offender_match_group

### DIFF
--- a/src/main/resources/db/migration/courtcase/R1__update_offender_match_group_apply_ids.sql
+++ b/src/main/resources/db/migration/courtcase/R1__update_offender_match_group_apply_ids.sql
@@ -1,0 +1,29 @@
+BEGIN;
+   -- Migrate existing records in offender_match_group so that they have case and defendant id
+    UPDATE offender_match_group omg
+    SET    case_id = t2.new_case_id ,
+           defendant_id = t2.defendant_id,
+           last_updated = now(),
+           last_updated_by = '(migration)'
+
+    FROM   offender_match_group  omg_from
+    JOIN
+            (
+                select cc.case_no , cc.court_code , cc.case_id as new_case_id, defendant_id from court_case cc
+                inner join
+                (
+                    select max(group_cc.created) as max_created, group_cc.case_id, defendant.defendant_id from court_case group_cc
+                    INNER JOIN defendant ON (defendant.court_case_id = group_cc.id)
+                    group by case_id, defendant.defendant_id
+                ) grouped_cases
+                on cc.case_id = grouped_cases.case_id
+                where cc.created = grouped_cases.max_created
+                and cc.deleted = false
+            ) t2
+    ON t2.court_code = omg_from.court_code AND t2.case_no = omg_from.case_no
+    WHERE omg.case_no = omg_from.case_no
+    and omg.court_code = omg_from.court_code
+    and omg.case_id is null
+    and omg.defendant_id is null;
+
+COMMIT;


### PR DESCRIPTION
This is the same SQL which has already been applied last time we did a flyway migration, except that 

- it constrains to leave records in `offender_match_group` which already have case and defendant id set
- it sets a `last_updated` timestamp
- it sets a `last_updated_by` value (migration)

I ran it in pre-prod just now