### PR TITLE
✨ PIC-1859 defendant sex may be null when received

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/Defendant.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/Defendant.java
@@ -34,8 +34,7 @@ public class Defendant {
     private final String probationStatus;
     @NotNull
     private final DefendantType type;
-    // Until CCM sends 'MALE' instead of 'M' we have to use a String here because this is a request and response object
-    @NotNull
+    // Until CCM sends 'MALE' instead of 'M' we have to use a String here because this is a request and response object. May be null from LIBRA.
     private final String sex;
     private final String crn;
     private final String pnc;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/DefendantTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/DefendantTest.java
@@ -1,0 +1,42 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DefendantTest {
+
+    @Test
+    void givenNullSex_whenGet_thenReturnNotKnown() {
+        // Consumers require "M", "F", "N", "NS" etc, via PACTs
+        assertThat(Defendant.builder().build().getSex()).isEqualTo("N");
+        assertThat(Defendant.builder().sex("   ").build().getSex()).isEqualTo("N");
+    }
+
+    @Test
+    void givenFemaleSex_whenGet_thenReturnM() {
+        assertThat(Defendant.builder().sex("female").build().getSex()).isEqualTo("F");
+        assertThat(Defendant.builder().sex("FEMALE").build().getSex()).isEqualTo("F");
+        assertThat(Defendant.builder().sex("F").build().getSex()).isEqualTo("F");
+    }
+
+    @Test
+    void givenMaleSex_whenGet_thenReturnF() {
+        assertThat(Defendant.builder().sex("maLE").build().getSex()).isEqualTo("M");
+        assertThat(Defendant.builder().sex("MALE").build().getSex()).isEqualTo("M");
+        assertThat(Defendant.builder().sex("M").build().getSex()).isEqualTo("M");
+    }
+
+    @Test
+    void givenNotKnownSex_whenGet_thenReturnN() {
+        assertThat(Defendant.builder().sex("NOT_KNOWN").build().getSex()).isEqualTo("N");
+        assertThat(Defendant.builder().sex("N").build().getSex()).isEqualTo("N");
+    }
+
+    @Test
+    void givenNotSpecifiedSex_whenGet_thenReturnNS() {
+        assertThat(Defendant.builder().sex("NOT_SPECIFIED").build().getSex()).isEqualTo("NS");
+        assertThat(Defendant.builder().sex("NS").build().getSex()).isEqualTo("NS");
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequestResponseTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedCourtCaseRequestResponseTest.java
@@ -69,7 +69,7 @@ class ExtendedCourtCaseRequestResponseTest {
     @Test
     void givenDefendantsWithOffences_whenAsEntity_thenReturn() {
 
-        final var defendant = buildDefendant();
+        final var defendant = buildDefendant("M");
 
         final var request = ExtendedCourtCaseRequestResponse.builder()
                 .defendants(List.of(defendant))
@@ -161,6 +161,22 @@ class ExtendedCourtCaseRequestResponseTest {
         assertThat(courtCaseEntity.getHearings()).isEmpty();
         assertThat(courtCaseEntity.getDefendants()).hasSize(1);
         assertThat(courtCaseEntity.getDefendants().get(0).getSex()).isEqualTo(Sex.MALE);
+    }
+
+    @Test
+    void givenNullSex_whenAsEntity_thenReturnAsNotKnown() {
+
+        final var request = ExtendedCourtCaseRequestResponse.builder()
+            .caseNo(CASE_NO)
+            .caseId(CASE_ID)
+            .defendants(List.of(buildDefendant(null)))
+            .build();
+
+        final var courtCaseEntity = request.asCourtCaseEntity();
+
+        assertThat(courtCaseEntity.getHearings()).isEmpty();
+        assertThat(courtCaseEntity.getDefendants()).hasSize(1);
+        assertThat(courtCaseEntity.getDefendants().get(0).getSex()).isEqualTo(Sex.NOT_KNOWN);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/SexTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/SexTest.java
@@ -19,6 +19,18 @@ class SexTest {
     }
 
     @Test
+    void whenNotSpecified_thenReturn() {
+        assertThat(Sex.fromString("NS")).isSameAs(Sex.NOT_SPECIFIED);
+        assertThat(Sex.fromString("NOT_SPECIFIED")).isSameAs(Sex.NOT_SPECIFIED);
+    }
+
+    @Test
+    void whenNotKnown_thenReturn() {
+        assertThat(Sex.fromString("N")).isSameAs(Sex.NOT_KNOWN);
+        assertThat(Sex.fromString("NOT_KNOWN")).isSameAs(Sex.NOT_KNOWN);
+    }
+
+    @Test
     void whenUnexpected_thenReturnNotKnown() {
         assertThat(Sex.fromString(null)).isSameAs(Sex.NOT_KNOWN);
         assertThat(Sex.fromString("     ")).isSameAs(Sex.NOT_KNOWN);


### PR DESCRIPTION
Only line of prod code is to remove an annotation, allowing defendant sex to be null (can happen from LIBRA), the rest is tests to cover