### PR TITLE
🗃 PIC-1615: Prevent optimistic locking failures for concurrent updates

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseService.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.controller.exceptions.ConflictingInputException;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
@@ -75,6 +77,7 @@ public class ImmutableCourtCaseService implements CourtCaseService {
     }
 
     @Override
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
     public Mono<CourtCaseEntity> createUpdateCaseForSingleDefendantId(String caseId, String defendantId, CourtCaseEntity updatedCase)
             throws EntityNotFoundException, InputMismatchException {
         validateEntityByDefendantId(caseId, defendantId, updatedCase);

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderMatchService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderMatchService.java
@@ -3,6 +3,8 @@ package uk.gov.justice.probation.courtcaseservice.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.annotation.RequestScope;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcaseservice.controller.model.GroupedOffenderMatchesRequest;
@@ -43,6 +45,7 @@ public class OffenderMatchService {
         this.offenderRestClient = offenderRestClientFactory.build();
     }
 
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
     public Mono<GroupedOffenderMatchesEntity> createOrUpdateGroupedMatchesByDefendant(String caseId, String defendantId, GroupedOffenderMatchesRequest offenderMatches) {
         return Mono.just(offenderMatchRepository.findByCaseIdAndDefendantId(caseId, defendantId)
             .map(existingGroup -> OffenderMatchMapper.update(caseId, defendantId, existingGroup, offenderMatches))


### PR DESCRIPTION
Having examined the code I'm pretty sure I can see where the issues are arising and it seems that we need a slightly higher level of isolation than the default (`Isolation.READ_COMMITTED`) to achieve this. Here's the documentation for `Isolation.REPEATABLE_READ` as its non-obvious. The issue I believe we're seeing is in bold italics:

> A constant indicating that dirty reads and non-repeatable reads are prevented; phantom reads can occur. This level prohibits a transaction from reading a row with uncommitted changes in it, and **_it also prohibits the situation where one transaction reads a row, a second transaction alters the row, and the first transaction rereads the row, getting different values the second time_** (a "non-repeatable read").