### PR TITLE
🔉 PIC-1946: Correct log message

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/application/ApplicationRetryListener.kt
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/application/ApplicationRetryListener.kt
@@ -30,6 +30,6 @@ class ApplicationRetryListener : RetryListener {
         callback: RetryCallback<T, E>?,
         throwable: Throwable?
     ) {
-        log.warn("Retried {} times. Last attempt failed with error", context?.retryCount, throwable)
+        log.warn("Retried {} times", context?.retryCount, throwable)
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/application/ApplicationRetryListenerTest.kt
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/application/ApplicationRetryListenerTest.kt
@@ -34,7 +34,7 @@ class ApplicationRetryListenerTest {
             "Retry attempt 1 failed with error",
             "Retry attempt 2 failed with error",
             "Retry attempt 3 failed with error",
-            "Retried 3 times. Last attempt failed with error"
+            "Retried 3 times"
         )
     }
 }


### PR DESCRIPTION
close method is also called on success so current message is misleading