### PR TITLE
🔥 PIC-2117: Remove redundant Snyk scan on docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,12 +197,6 @@ jobs:
                --label "build.number=$CIRCLE_BUILD_NUM" \
                --label "build.url=$CIRCLE_BUILD_URL" \
                --label "build.gitref=$CIRCLE_SHA1"
-      - snyk/scan:
-          project: '${CIRCLE_PROJECT_REPONAME}-docker/${CIRCLE_BRANCH}'
-          docker-image-name: 'hmpps/<<parameters.app_name>>:$APP_VERSION'
-          target-file: '<<parameters.dockerfile_path>>/Dockerfile'
-          monitor-on-build: << parameters.main >>
-          <<: *snyk_options
       - when:
           condition: << parameters.main >>
           steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-oraclelinux8
+FROM openjdk:16-oraclelinux7
 MAINTAINER HMPPS Digital Studio <info@digital.justice.gov.uk>
 
 RUN yum update -yq


### PR DESCRIPTION
The snyk scan on docker_build is blocking merges of new features and disrupting our workflow. As this scan is performed on a scheduled basis on main anyway this doesn't provide much additional value so deleting.