### PR TITLE
Revert "PIC-2563 (#964)"

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2131__set_unique_personid_per_defendantid.sql
+++ b/src/main/resources/db/migration/courtcase/V2131__set_unique_personid_per_defendantid.sql
@@ -1,7 +1,0 @@
-BEGIN;
-
- UPDATE  DEFENDANT SET   person_id = uuid_generate_v4()
- FROM    DEFENDANT  AS d1
- WHERE   DEFENDANT.defendant_id = d1.defendant_id ;
-
-COMMIT;


### PR DESCRIPTION
This reverts commit 90520e10fc7c67960acac519e40425de584610cf which is no longer needed and has been causing problems when migrating the Prod DB. I've run flywayRepair on the dev and preprod Flyway migrations so that this will deploy.