### PR TITLE
🛠 PIC-2633: Increase allowed startup time and reduce surge count

### DIFF
--- a/helm_deploy/court-case-service/templates/deployment.yaml
+++ b/helm_deploy/court-case-service/templates/deployment.yaml
@@ -31,6 +31,13 @@ spec:
           ports:
             - containerPort: {{ .Values.image.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.image.port }}
+            initialDelaySeconds: 60
+            failureThreshold: 180
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /ping

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -3,7 +3,7 @@
 
 minReplicaCount: 2
 maxReplicaCount: 8
-maxSurge: 2
+maxSurge: 1
 takeDatabaseSnapshots: false
 
 image:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,7 +3,7 @@
 
 minReplicaCount: 2
 maxReplicaCount: 8
-maxSurge: 2
+maxSurge: 1
 takeDatabaseSnapshots: true
 
 image:


### PR DESCRIPTION
This is to prevent pod restarts and failed deployment where time consuming migrations need to be applied