### PR TITLE
PIC-2655 Ensure Short Term Custody algorithm returns P1 score

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.34.0")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.0")
 
     testImplementation("au.com.dius.pact.provider:junit5spring:$pactVersion")
     testImplementation("au.com.dius.pact.provider:junit5:$pactVersion")

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorService.kt
@@ -23,15 +23,15 @@ class ShortTermCustodyPredictorService(
     private val model: EasyPredictModelWrapper,
     private val offencesRestClient: ManageOffencesRestClient
 ) {
-
     companion object {
         val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+        private const val P1_SCORE_INDEX = 1
 
         fun isMagistratesCourtCode(courtCode: String) : Boolean {
             return courtCode.startsWith("B")
         }
     }
-
     fun calculateShortTermCustodyPredictorScore(shortTermCustodyPredictorParameters: ShortTermCustodyPredictorParameters) : Double? {
 
         log.debug("Entered calculateShortTermCustodyPredictorScore(${shortTermCustodyPredictorParameters.courtCode}, " +
@@ -56,7 +56,7 @@ class ShortTermCustodyPredictorService(
         }
 
         prediction?.let {
-            val score = prediction.classProbabilities[0]
+            val score = prediction.classProbabilities[P1_SCORE_INDEX]
             log.info("Calculated short term custody score of $score for court code: ${shortTermCustodyPredictorParameters.courtCode}, offender age: ${shortTermCustodyPredictorParameters.offenderAge}, offence code: ${shortTermCustodyPredictorParameters.offenceCode}")
             return score
         }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutByHearingIdIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerPutByHearingIdIntTest.java
@@ -235,7 +235,7 @@ class CourtCaseControllerPutByHearingIdIntTest extends BaseIntTest {
             assertThat(hearingEntity.getHearingEventType().getName()).isEqualTo("ConfirmedOrUpdated");
             assertThat(hearingEntity.getHearingType()).isEqualTo("sentenced");
             assertThat(hearingEntity.getHearingDefendants().get(0).getOffences()).extracting("listNo").containsOnly(5, 8);
-            assertThat(hearingEntity.getHearingDefendants().get(0).getOffences()).extracting("shortTermCustodyPredictorScore").containsOnly(BigDecimal.valueOf(0.9649235740260149));
+            assertThat(hearingEntity.getHearingDefendants().get(0).getOffences()).extracting("shortTermCustodyPredictorScore").containsOnly(BigDecimal.valueOf(0.035076425973985095));
             assertThat(hearingEntity.getHearingDefendants().get(0).getDefendant().getPhoneNumber()).isEqualTo(
                     PhoneNumberEntity.builder().home("07000000013").mobile("07000000014").work("07000000015").build());
             assertThat(hearingEntity.getHearingDefendants().get(0).getDefendant().getPersonId()).isNotBlank();
@@ -393,7 +393,7 @@ class CourtCaseControllerPutByHearingIdIntTest extends BaseIntTest {
         // Then
         courtCaseRepository.findFirstByHearingId(hearingId).ifPresentOrElse(hearing ->
             assertThat(hearing.getHearingDefendants().get(0).getOffences())
-                    .anyMatch(offenceEntity -> offenceEntity.getShortTermCustodyPredictorScore().compareTo(BigDecimal.valueOf(0.8938871700060149)) == 0),
+                    .anyMatch(offenceEntity -> offenceEntity.getShortTermCustodyPredictorScore().compareTo(BigDecimal.valueOf(0.10611282999398507)) == 0),
             () -> fail("Short Term Custody score should be persisted"));
 
     }

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorServiceIntTest.kt
@@ -76,7 +76,7 @@ class ShortTermCustodyPredictorServiceIntTest : BaseIntTest() {
 
         // Then
         assertThat(custodyPredictorScore).isNotNull
-        assertThat(custodyPredictorScore).isEqualTo(0.9311253572283462)
+        assertThat(custodyPredictorScore).isEqualTo(0.0688746427716538)
     }
 
     @Test
@@ -123,7 +123,7 @@ class ShortTermCustodyPredictorServiceIntTest : BaseIntTest() {
         val custodyPredictorScore = predictorService.calculateShortTermCustodyPredictorScore(shortTermCustodyPredictorParameters)
 
         // Then
-        assertThat(custodyPredictorScore).isEqualTo(0.9870862213669677)
+        assertThat(custodyPredictorScore).isEqualTo(0.012913778633032313)
     }
 
     companion object {


### PR DESCRIPTION
- Data science have detected that the incorrect score (P0) is being returned from the algorithm
- Fix to return P1 score instead