### PR TITLE
PIC-2592 Increase k8s pod memory limit

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -69,5 +69,5 @@ resources:
     limit: 5000m
     request: 500m
   memory:
-    limit: 1200Mi
+    limit: 1600Mi
     request: 700Mi

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -76,5 +76,5 @@ resources:
     limit: 5000m
     request: 500m
   memory:
-    limit: 1200Mi
+    limit: 1600Mi
     request: 700Mi


### PR DESCRIPTION
*Increase memory limit for CCS Pods to 1600Mi for pre-prod and prod environments