### PR TITLE
[do not merge] Abdi testing

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE if exists hearing_outcome_aud ADD COLUMN fk_hearing_defendant_id integer ;
+
+END;

--- a/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
@@ -1,9 +1,9 @@
 BEGIN;
 
-ALTER TABLE if exists hearing_outcome_aud ADD COLUMN fk_hearing_defendant_id integer;
+ALTER TABLE hearing_outcome_aud ADD COLUMN IF NOT EXISTS fk_hearing_defendant_id integer;
 
-ALTER TABLE if exists hearing_outcome_aud ADD COLUMN LEGACY boolean NOT NULL DEFAULT FALSE;
+ALTER TABLE hearing_outcome_aud ADD COLUMN IF NOT EXISTS LEGACY boolean NOT NULL DEFAULT FALSE;
 
-ALTER TABLE if exists hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
+ALTER TABLE hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
 
 END;

--- a/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
@@ -1,5 +1,9 @@
 BEGIN;
 
-ALTER TABLE if exists hearing_outcome_aud ADD COLUMN fk_hearing_defendant_id integer ;
+ALTER TABLE if exists hearing_outcome_aud ADD COLUMN fk_hearing_defendant_id integer;
+
+ALTER TABLE if exists hearing_outcome_aud ADD COLUMN LEGACY boolean NOT NULL DEFAULT FALSE;
+
+ALTER TABLE if exists hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
 
 END;

--- a/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
@@ -1,7 +1,7 @@
 BEGIN;
-    ALTER TABLE if exists hearing_outcome_aud ADD COLUMN IF NOT EXISTS fk_hearing_defendant_id integer;
+    ALTER TABLE courtcaseservice.hearing_outcome_aud ADD COLUMN IF NOT EXISTS fk_hearing_defendant_id integer;
 
-    ALTER TABLE if exists  hearing_outcome_aud ADD COLUMN IF NOT EXISTS LEGACY boolean NOT NULL DEFAULT FALSE;
+    ALTER TABLE courtcaseservice.hearing_outcome_aud ADD COLUMN IF NOT EXISTS LEGACY boolean NOT NULL DEFAULT FALSE;
 
-    ALTER TABLE if exists hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
+    ALTER TABLE courtcaseservice.hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
 END;

--- a/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
+++ b/src/main/resources/db/migration/courtcase/V2176__add_audit_column_for_hearing_outcome_fk_hearing_defendant_id.sql
@@ -1,9 +1,7 @@
 BEGIN;
+    ALTER TABLE if exists hearing_outcome_aud ADD COLUMN IF NOT EXISTS fk_hearing_defendant_id integer;
 
-ALTER TABLE hearing_outcome_aud ADD COLUMN IF NOT EXISTS fk_hearing_defendant_id integer;
+    ALTER TABLE if exists  hearing_outcome_aud ADD COLUMN IF NOT EXISTS LEGACY boolean NOT NULL DEFAULT FALSE;
 
-ALTER TABLE hearing_outcome_aud ADD COLUMN IF NOT EXISTS LEGACY boolean NOT NULL DEFAULT FALSE;
-
-ALTER TABLE hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
-
+    ALTER TABLE if exists hearing_outcome_aud ADD CONSTRAINT fk_hearing_defendant_hearing_outcome FOREIGN KEY (fk_hearing_defendant_id) REFERENCES hearing_defendant;
 END;


### PR DESCRIPTION
testing where the hearing_outcome_aud table is


looks like the audit tables don't exist during flyway migrations due to hbm2ddl not being set to create, create-drop or update

