### PR TITLE
Increase the Nginx/ingress body size limit for requests for DEV

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,10 @@ ingress:
   hosts:
     - host: court-case-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_max_body_size 100m;
 
 nginx_proxy:
   name: court-case-service-proxy


### PR DESCRIPTION
### Increase the Nginx/ingress body size limit for requests for DEV


This is because prepare a case service is getting a 413 http response
"client intended to send too large body: 6156882 bytes" as it tries to upload a 6mb file.

The Cloud Platform Kibana Ingress Logs suggest it's due to the `court-case-service-proxy` ingress server defaulting to a max of 1megabyte


**Additional information:**

https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#custom-max-body-size

