### PR TITLE
Increase client_max_body_size in nginx/ingress

### DIFF
--- a/helm_deploy/court-case-service/templates/ingress.yaml
+++ b/helm_deploy/court-case-service/templates/ingress.yaml
@@ -25,6 +25,7 @@ metadata:
         deny all;
         return 403;
       }
+      client_max_body_size 50M;
 spec:
   ingressClassName: modsec
   tls:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,10 +19,6 @@ ingress:
   hosts:
     - host: court-case-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: 100m
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_max_body_size 100m;
 
 nginx_proxy:
   name: court-case-service-proxy

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,6 +20,8 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
+    client_max_body_size 50M;
+
     sendfile        on;
 
     keepalive_timeout  65;


### PR DESCRIPTION
Increase the file upload size limit to 50M by updating the nginx.conf file `client_max_body_size` value and also updating the ingress.yaml

This is to allow a large file upload from prepare-a-case service. The default nginx limit is 1mb which isn't enough.

Undo this previous PR as we have an nginx.conf file available: https://github.com/ministryofjustice/court-case-service/pull/1182

