### PR TITLE
Fix Swagger OpenAPI documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,10 +166,8 @@ dependencies {
     implementation("net.minidev:json-smart:2.4.9") {
         because("SNYK scan reported secuity vulnerability in the bundled net.minidev:json-smart:2.4.8")
     }
-
-    implementation("org.springdoc:springdoc-openapi-ui:1.7.0") {
-        because("SNYK scan reported secuity vulnerability in the bundled org.springdoc:springdoc-openapi-ui:1.6.13")
-    }
+    
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.4.0'
 
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3")
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3')

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,6 @@ dependencies {
     }
 
     // Open API Documentation
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-common', version: '2.5.0'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -166,8 +166,12 @@ dependencies {
     implementation("net.minidev:json-smart:2.4.9") {
         because("SNYK scan reported secuity vulnerability in the bundled net.minidev:json-smart:2.4.8")
     }
-    
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.4.0'
+
+    // Open API Documentation
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-common', version: '2.5.0'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
+
+
 
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3")
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3')

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CaseSearchController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CaseSearchController.java
@@ -1,9 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.controller;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,13 +14,6 @@ import jakarta.validation.Valid;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@OpenAPIDefinition(info =
-@Info(
-    title = "court-case-service search",
-    description = "API to search cases by defendant parameters.",
-    license = @License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE")
-)
-)
 @Tag(name = "Court Case Search Resources")
 @RestController
 public class CaseSearchController {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
@@ -68,13 +69,6 @@ import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@OpenAPIDefinition(info =
-@Info(
-        title = "court-case-service",
-        description = "Service to access court cases imported from HMCTS Libra and Common Platform court lists",
-        license = @License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE")
-)
-)
 @Tag(name = "Court Case Resources")
 @RestController
 public class CourtCaseController {

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/CourtCaseServiceApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/CourtCaseServiceApplication.kt
@@ -1,5 +1,11 @@
 package uk.gov.justice.probation.courtcaseservice
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.security.SecurityScheme
+import io.swagger.v3.oas.annotations.servers.Server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/config/OpenAPIConfiguration.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.probation.courtcaseservice.config
+
+class OpenAPIConfiguration {
+}

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/config/OpenAPIConfiguration.kt
@@ -1,4 +1,37 @@
 package uk.gov.justice.probation.courtcaseservice.config
 
-class OpenAPIConfiguration {
-}
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.info.License
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.security.SecurityScheme
+import io.swagger.v3.oas.annotations.servers.Server
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+
+
+@Configuration
+@OpenAPIDefinition(
+    info = io.swagger.v3.oas.annotations.info.Info(
+        title = "Court Case Service API Documentation",
+        description = "API to access court cases imported from HMCTS Libra court lists and Common Platform.",
+        contact = io.swagger.v3.oas.annotations.info.Contact(
+            name = "Probation In Court Team",
+            email = "",
+            url = "https://moj.enterprise.slack.com/archives/C01FR4HKS3A", // #pic-mafia Slack channel
+        ),
+        license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE"),
+        version = "1.0",
+    ),
+    security = [SecurityRequirement(name = "hmpps-auth-token")],
+)
+@SecurityScheme(
+    name = "hmpps-auth-token",
+    scheme = "bearer",
+    bearerFormat = "JWT",
+    type = SecuritySchemeType.HTTP,
+    `in` = SecuritySchemeIn.HEADER,
+    paramName = HttpHeaders.AUTHORIZATION,
+)
+class OpenAPIConfiguration

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/CaseWorkflowController.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/CaseWorkflowController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.*
@@ -34,7 +35,7 @@ class CaseWorkflowController(val caseWorkflowService: CaseWorkflowService, val a
 
     @Operation(description = "Fetch hearing outcomes")
     @GetMapping(value = ["/courts/{courtCode}/hearing-outcomes"], produces = [APPLICATION_JSON_VALUE])
-    fun fetchHearingOutcomes(@PathVariable("courtCode") courtCode: String, @Valid hearingOutcomeSearchRequest: HearingOutcomeSearchRequest): HearingOutcomeCaseList {
+    fun fetchHearingOutcomes(@PathVariable("courtCode") courtCode: String, @Valid @ParameterObject hearingOutcomeSearchRequest: HearingOutcomeSearchRequest): HearingOutcomeCaseList {
         return caseWorkflowService.fetchHearingOutcomes(courtCode, hearingOutcomeSearchRequest)
     }
 


### PR DESCRIPTION
# Add swagger dependency for spring boot 3

- Remove the `org.springdoc:springdoc-openapi-ui:1.7.0` that only supports springboot 1 and 2

- Add `springdoc-openapi-starter-webmvc-ui` that supports Spring Boot 3

This fixes the endpoint `/swagger-ui.html`

Allowing users to read and use the api documentation

- Fix one of the endpoints documentation as it was using an Object for the query param so it needs to use the `@ParameterObject`
- Implement OAuth2 Bearer Token with Swagger Document
      - I believe that in order to get the token for preprod/prod, you'll need to use the auth code grant flow. For Dev, you can use the client credentials found in its k8s secrets.

<img width="1294" alt="image of api documentation example" src="https://github.com/ministryofjustice/court-case-service/assets/25043924/4dc58962-d69b-4245-aa8c-3abf2606ebf4">

