### PR TITLE
Fix Critical Security Vulnerability found by SNYK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ dependencies {
 
     runtimeOnly 'org.flywaydb:flyway-core'
     runtimeOnly "org.springframework.boot:spring-boot-devtools"
-    runtimeOnly 'org.postgresql:postgresql:42.6.0'
+    runtimeOnly 'org.postgresql:postgresql:42.6.1'
 
     implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 


### PR DESCRIPTION
# Fix Critical Security Vulnerability found by SNYK

Upgrade o`rg.postgresql:postgresql` to `42.6.1
`This fixes a critical security vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-6252740

Preventing SQL Injections.