### PR TITLE
PIC-3725 and PIC-3808 Return all Assigned Users for court & Create V2 endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/CaseWorkflowController.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/CaseWorkflowController.kt
@@ -2,17 +2,27 @@ package uk.gov.justice.probation.courtcaseservice.controller
 
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterStyle
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import uk.gov.justice.probation.courtcaseservice.controller.model.*
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.*
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingDefendantOutcomesRequest
 import uk.gov.justice.probation.courtcaseservice.service.AuthenticationHelper
 import uk.gov.justice.probation.courtcaseservice.service.CaseWorkflowService
 import uk.gov.justice.probation.courtcaseservice.service.HearingOutcomeType
+import uk.gov.justice.probation.courtcaseservice.service.PaginatedHeadersService
+import uk.gov.justice.probation.courtcaseservice.service.v2.FilterHearingDefendantOutcomesService
 import java.security.Principal
+import java.util.*
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCaseList as V2HearingOutcomeCaseList
 
 @Tag(name = "Case workflow API")
 @RestController
@@ -63,4 +73,23 @@ class CaseWorkflowController(val caseWorkflowService: CaseWorkflowService, val a
         @PathVariable("prepStatus") prepStatus: HearingPrepStatus
     ) = caseWorkflowService.updatePrepStatus(hearingId, defendantId, prepStatus)
 
+
+//    V2 endpoints
+
+    @Operation(description = "Fetch hearing defendant outcomes")
+    @GetMapping(value = ["/v2/courts/{courtCode}/hearing-defendant-outcomes"], produces = [APPLICATION_JSON_VALUE])
+    fun fetchHearingDefendantOutcomesV2(@PathVariable("courtCode") courtCode: String,
+                                        @Valid @ParameterObject searchRequest: HearingDefendantOutcomesRequest
+    ): ResponseEntity<FilteredHearingDefendantOutcomesResponse> {
+
+        val hearingDefendantOutcomes: V2HearingOutcomeCaseList = caseWorkflowService.fetchV2HearingDefendantOutcomes(courtCode, searchRequest)
+
+        val filteredResponse = FilterHearingDefendantOutcomesService(hearingDefendantOutcomes).getResponse()
+
+        val paginatedHeaders = PaginatedHeadersService().getHeaders(hearingDefendantOutcomes.page, searchRequest.size, hearingDefendantOutcomes.totalPages, hearingDefendantOutcomes.totalElements)
+
+        return ResponseEntity.ok()
+            .headers(paginatedHeaders)
+            .body<FilteredHearingDefendantOutcomesResponse>(filteredResponse)
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/HearingOutcomeCaseList.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/HearingOutcomeCaseList.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.controller.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingOutcomeAssignedUser
 
 @Schema(description = "Hearing outcome response model")
 data class HearingOutcomeCaseList(
@@ -9,5 +10,6 @@ data class HearingOutcomeCaseList(
     val courtRoomFilters: List<String> = listOf(),
     val totalPages: Int = 0,
     val page: Int = 0,
-    val totalElements: Int = 0
+    val totalElements: Int = 0,
+    val assignedUsers: List<HearingOutcomeAssignedUser>
 )

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilterItem.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilterItem.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.filters
+
+open class FilterItem(val id: String?, val name: String?, val active: Boolean)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilteredOutcomesResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilteredOutcomesResponse.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.filters
+
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeResponse
+
+data class FilteredHearingDefendantOutcomesResponse(
+    override val records: List<HearingOutcomeResponse>,
+    override val filters: MutableList<FiltersList>
+): FilteredResourcesResponse(records, filters)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilteredResourcesResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FilteredResourcesResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.filters
+
+open class FilteredResourcesResponse(
+    open val records: Any?,
+    open val filters: MutableList<FiltersList>
+)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FiltersList.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/FiltersList.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.filters
+
+class FiltersList(val id: String, val name: String, val multiple: Boolean, val items: List<Any>)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/HearingOutcomeStatesFilterItem.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/filters/HearingOutcomeStatesFilterItem.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.filters
+
+class HearingOutcomeStatesFilterItem(id: String?, name: String?, val matches: Int, active: Boolean) : FilterItem(id, name, active)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingDefendantOutcomesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingDefendantOutcomesRequest.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.v2
+
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSortFields
+import uk.gov.justice.probation.courtcaseservice.controller.model.SortOrder
+import uk.gov.justice.probation.courtcaseservice.service.HearingOutcomeType
+
+
+data class HearingDefendantOutcomesRequest(
+    val outcomeTypes: List<HearingOutcomeType>? = listOf(),
+    val state: HearingOutcomeItemState? = null,
+    val assignedUsers: List<String>? = listOf(),
+    val courtRooms: List<String> = listOf(),
+    val page: Int = 1,
+    val size: Int = 20,
+    val sortBy: HearingOutcomeSortFields? = null,
+    val order: SortOrder? = SortOrder.ASC
+)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingOutcomeCaseList.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingOutcomeCaseList.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.v2
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeResponse
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingOutcomeAssignedUser
+
+@Schema(description = "V2 Hearing outcome response model")
+data class HearingOutcomeCaseList(
+    val records: List<HearingOutcomeResponse> = listOf(),
+    val countsByState: HearingOutcomeCountByState? = null,
+    val courtRoomFilters: List<String> = listOf(),
+    val totalPages: Int = 0,
+    val page: Int = 0,
+    val totalElements: Int = 0,
+    val assignedUsers: List<HearingOutcomeAssignedUser> = listOf()
+)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingOutcomeCountByState.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/controller/model/v2/HearingOutcomeCountByState.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.probation.courtcaseservice.controller.model.v2
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Hearing outcome counts by workflow state.")
+data class HearingOutcomeCountByState(
+    val counts: List<Pair<String, Int>>
+)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingOutcomeAssignedUser.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingOutcomeAssignedUser.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.probation.courtcaseservice.jpa.entity
+
+data class HearingOutcomeAssignedUser(
+    val name: String?,
+    val uuid: String?
+)

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustom.kt
@@ -7,8 +7,6 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcome
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSortFields.HEARING_DATE
 import java.time.LocalDate
 import jakarta.persistence.EntityManager
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingDefendantEntity
 
 @Repository
@@ -20,9 +18,7 @@ class HearingOutcomeRepositoryCustom(
     fun findByCourtCodeAndHearingOutcome(
         courtCode: String,
         hearingOutcomeSearchRequest: HearingOutcomeSearchRequest
-    ): PageImpl<Pair<HearingDefendantEntity, LocalDate>> {
-        val pageable: Pageable = Pageable.ofSize(hearingOutcomeSearchRequest.size).withPage(if (hearingOutcomeSearchRequest.page > 0) hearingOutcomeSearchRequest.page - 1 else 0)
-
+    ): List<Pair<HearingDefendantEntity, LocalDate>> {
         val filterBuilder = StringBuilder()
 
         val queryParams = LinkedHashMap<String, Any>()
@@ -33,9 +29,9 @@ class HearingOutcomeRepositoryCustom(
             queryParams["state"] = it.name
 
             // a special case for resulted cases state to return only cases resulted within the last resultedCasesDaysOffset (default 14) days
-            if(it == HearingOutcomeItemState.RESULTED) {
+            if (it == HearingOutcomeItemState.RESULTED) {
                 filterBuilder.append(" and ho.resulted_date > :resultedDate ")
-                queryParams["resultedDate"] = LocalDate.now().minusDays(resultedCasesDaysOffset).atTime(0,0,0)
+                queryParams["resultedDate"] = LocalDate.now().minusDays(resultedCasesDaysOffset).atTime(0, 0, 0)
             }
         }
 
@@ -69,7 +65,7 @@ class HearingOutcomeRepositoryCustom(
         val courtRoomParamName = "courtRoom"
 
         val hasCourtRoomFilter = hearingOutcomeSearchRequest.courtRoom.isNotEmpty()
-        if(hasCourtRoomFilter) {
+        if (hasCourtRoomFilter) {
             queryParams[courtRoomParamName] = hearingOutcomeSearchRequest.courtRoom
         }
 
@@ -81,7 +77,7 @@ class HearingOutcomeRepositoryCustom(
                 (
                     select fk_hearing_id as hday_hearing_id, min(hearing_day) as hearing_day from hearing_day
                         where hearing_day.court_code = :courtCode
-                        ${ if(hasCourtRoomFilter) " and hearing_day.court_room in (:$courtRoomParamName) " else "" }
+                        ${if (hasCourtRoomFilter) " and hearing_day.court_room in (:$courtRoomParamName) " else ""}
                         group by fk_hearing_id
                 ) hday2
             on hday2.hday_hearing_id = hd.fk_hearing_id	
@@ -109,13 +105,8 @@ class HearingOutcomeRepositoryCustom(
             countJpaQuery.setParameter(it.key, it.value)
         }
 
-        jpaQuery.firstResult  = pageable.pageNumber * pageable.pageSize
-        jpaQuery.maxResults = pageable.pageSize
-
-        val content = jpaQuery.resultList.map { it as Array<Any> }.map { Pair(it[0] as HearingDefendantEntity, it[1] as LocalDate) }
-        val count = (countJpaQuery.singleResult as Long)
-
-        return PageImpl(content, pageable, count)
+        return jpaQuery.resultList.map { it as Array<Any> }
+            .map { Pair(it[0] as HearingDefendantEntity, it[1] as LocalDate) }
     }
 
     fun getDynamicOutcomeCountsByState(courtCode: String): Map<String, Int> {

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/HearingOutcomeType.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/HearingOutcomeType.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.probation.courtcaseservice.service
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
 
+
+@Schema(implementation = HearingOutcomeType::class)
 enum class HearingOutcomeType(@JsonProperty("hearingOutcomeType") val value: String) {
 
     PROBATION_SENTENCE("Probation sentence"),

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/PaginatedHeadersService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/PaginatedHeadersService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.probation.courtcaseservice.service
+
+import org.springframework.http.HttpHeaders
+
+class PaginatedHeadersService {
+
+    fun getHeaders(page: Int, size: Int, totalPages: Int, totalElements: Int): HttpHeaders {
+        val responseHeaders = HttpHeaders()
+        responseHeaders.set("X-PAGINATION-CURRENT-PAGE", java.lang.String.valueOf(page))
+        responseHeaders.set("X-PAGINATION-PAGE-SIZE", java.lang.String.valueOf(size))
+        responseHeaders.set("X-PAGINATION-TOTAL-PAGES", java.lang.String.valueOf(totalPages))
+        responseHeaders.set("X-PAGINATION-TOTAL-RESULTS", java.lang.String.valueOf(totalElements))
+
+        return responseHeaders
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesService.kt
@@ -15,7 +15,7 @@ class FilterHearingDefendantOutcomesService(private val hearingDefendantOutcomes
         var filters: MutableList<FiltersList> = mutableListOf();
         filters.add(FiltersList("assignedUsers", "Assigned Users", true, assignedUsers))
         filters.add(FiltersList("courtRooms", "Court Rooms", true, courtRooms))
-        filters.add(FiltersList("states", "Hearing Outcome States", true, hearingOutcomeStates))
+        filters.add(FiltersList("states", "Hearing Outcome States", false, hearingOutcomeStates))
 
         return FilteredHearingDefendantOutcomesResponse(hearingDefendantOutcomes.records, filters)
     }

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesService.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.probation.courtcaseservice.service.v2
+
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.*
+
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCaseList as V2HearingOutcomeCaseList
+
+class FilterHearingDefendantOutcomesService(private val hearingDefendantOutcomes: V2HearingOutcomeCaseList) {
+
+    fun getResponse(): FilteredHearingDefendantOutcomesResponse {
+        val assignedUsers: List<FilterItem> = hearingDefendantOutcomes.assignedUsers.map { (name, id) -> FilterItem(id, name, true) }
+        val courtRooms: List<FilterItem> = hearingDefendantOutcomes.courtRoomFilters.map { court -> FilterItem(court, court, true) }
+        val hearingOutcomeStates: List<FilterItem> = getFilterableHearingOutcomeStates()
+
+        var filters: MutableList<FiltersList> = mutableListOf();
+        filters.add(FiltersList("assignedUsers", "Assigned Users", true, assignedUsers))
+        filters.add(FiltersList("courtRooms", "Court Rooms", true, courtRooms))
+        filters.add(FiltersList("states", "Hearing Outcome States", true, hearingOutcomeStates))
+
+        return FilteredHearingDefendantOutcomesResponse(hearingDefendantOutcomes.records, filters)
+    }
+
+    private fun getFilterableHearingOutcomeStates(): List<FilterItem>{
+        return enumValues<HearingOutcomeItemState>().toList().map {
+                state -> HearingOutcomeStatesFilterItem(
+                state.name,
+                state.name.split("_").joinToString(" ") { it.lowercase().replaceFirstChar(Char::uppercaseChar) },
+                hearingDefendantOutcomeStateMatches(state),
+                true
+            )
+        }
+    }
+
+    private fun hearingDefendantOutcomeStateMatches(state: HearingOutcomeItemState): Int{
+        val matches = hearingDefendantOutcomes.countsByState?.counts?.find { it.first == state.name }
+        if (matches != null) return matches.second!!.toInt() else return 0;
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/controller/v2/CaseWorkflowControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/controller/v2/CaseWorkflowControllerIntTest.kt
@@ -1,0 +1,290 @@
+package uk.gov.justice.probation.courtcaseservice.controller.v2
+
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase
+import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.test.context.jdbc.SqlConfig.TransactionMode
+import org.springframework.web.util.UriComponentsBuilder
+import uk.gov.justice.probation.courtcaseservice.BaseIntTest
+import uk.gov.justice.probation.courtcaseservice.jpa.repository.HearingRepository
+import uk.gov.justice.probation.courtcaseservice.service.CaseWorkflowService
+import uk.gov.justice.probation.courtcaseservice.testUtil.TokenHelper
+import java.net.URI
+
+
+@Sql(
+    scripts = ["classpath:sql/before-common.sql", "classpath:case-progress.sql"],
+    config = SqlConfig(transactionMode = TransactionMode.ISOLATED)
+)
+@Sql(
+    scripts = ["classpath:after-test.sql"],
+    config = SqlConfig(transactionMode = TransactionMode.ISOLATED),
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD
+)
+internal class CaseWorkflowControllerIntTest: BaseIntTest() {
+
+    companion object {
+        const val HEARING_ID = "1f93aa0a-7e46-4885-a1cb-f25a4be33a00"
+        const val DEFENDANT_ID = "40db17d6-04db-11ec-b2d8-0242ac130002"
+        const val UNKNOWN_HEARING_ID = "111111-1111-1111-1111-111111111111"
+        const val HEARING_OUTCOME_REQUEST: String = "{ \"hearingOutcomeType\": \"ADJOURNED\" }"
+        const val HEARING_OUTCOME_UPDATE_REQUEST: String = "{ \"hearingOutcomeType\": \"REPORT_REQUESTED\" }"
+        const val HEARING_OUTCOME_ASSIGN_REQUEST: String = "{ \"assignedTo\": \"John Smith\" }"
+    }
+
+    @Autowired
+    lateinit var hearingRepository: HearingRepository
+
+    @SpyBean
+    lateinit var caseWorkflowService: CaseWorkflowService
+
+    @Test
+    fun `V2 given court code and outcome state NEW and filters should return all outcomes for that court with pagination headers`() {
+
+        val courtCode = "B33HU"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+            .queryParam("hearingOutcomeState", "NEW")
+            .queryParam("hearingOutcomeOutcomeType",  "PROBATION_SENTENCE", "ADJOURNED")
+            .queryParam("sortBy",  "hearingDate")
+            .queryParam("order",  "DESC")
+            .build().toUriString()
+
+        given()
+            .auth()
+            .oauth2(TokenHelper.getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .`when`()
+            .get(endpoint)
+            .then()
+            .statusCode(200)
+            .header("X-PAGINATION-CURRENT-PAGE", equalTo("1"))
+            .header("X-PAGINATION-PAGE-SIZE", equalTo("20"))
+            .header("X-PAGINATION-TOTAL-PAGES", equalTo("1"))
+            .header("X-PAGINATION-TOTAL-RESULTS", equalTo("1"))
+            .body("records", hasSize<Any>(1))
+            .body("records[0].hearingOutcomeType", equalTo("ADJOURNED"))
+            .body("records[0].outcomeDate", equalTo("2023-04-24T09:09:09"))
+            .body("records[0].hearingId", equalTo("2aa6f5e0-f842-4939-bc6a-01346abc09e7"))
+            .body("records[0].hearingDate", equalTo("2019-10-14"))
+            .body("records[0].defendantId", equalTo("40db17d6-04db-11ec-b2d8-0242ac130002"))
+            .body("records[0].defendantName", equalTo("Mr Johnny BALL"))
+            .body("records[0].offences", equalTo(listOf("Theft from a different shop", "Theft from a shop")))
+            .body("records[0].probationStatus", equalTo("Current"))
+            .body("filters[0]['name']", equalTo("Assigned Users"))
+            .body("filters[0]['id']", equalTo("assignedUsers"))
+            .body("filters[0]['items'][0]['id']", equalTo("4b03d065-4c96-4b24-8d6d-75a45d2e3f12"))
+            .body("filters[0]['items'][0]['name']", equalTo("Joe Blogs"))
+            .body("filters[2]['id']", equalTo("states"))
+            .body("filters[2]['name']", equalTo("Hearing Outcome States"))
+            .body("filters[2]['items'][0]['id']", equalTo("NEW"))
+            .body("filters[2]['items'][0]['matches']", equalTo(1))
+    }
+
+    @Test
+    fun `given court code and outcome state IN_PROGRESS return all outcomes for that court`() {
+
+        val courtCode = "B10JQ"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+                .queryParam("state", "IN_PROGRESS")
+                .build().toUriString()
+
+        given()
+                .auth()
+                .oauth2(TokenHelper.getToken())
+                .accept(ContentType.JSON)
+                .`when`()
+                .get(endpoint)
+                .then()
+                .statusCode(200)
+                .header("X-PAGINATION-CURRENT-PAGE", equalTo("1"))
+                .header("X-PAGINATION-PAGE-SIZE", equalTo("20"))
+                .header("X-PAGINATION-TOTAL-PAGES", equalTo("1"))
+                .header("X-PAGINATION-TOTAL-RESULTS", equalTo("2"))
+                .body("records", hasSize<Any>(2))
+                .body("records[0].hearingOutcomeType", equalTo("ADJOURNED"))
+                .body("records[0].outcomeDate", equalTo("2023-04-24T09:09:09"))
+                .body("records[0].hearingId", equalTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00"))
+                .body("records[0].hearingDate", equalTo("2019-11-14"))
+                .body("records[0].defendantId", equalTo("40db17d6-04db-11ec-b2d8-0242ac130002"))
+                .body("records[0].defendantName", equalTo("Mr Johnny BALL"))
+                .body("records[0].probationStatus", equalTo("Current"))
+                .body("records[0].assignedTo", equalTo("John Smith"))
+                .body("records[0].assignedToUuid", equalTo("8f69def4-3c52-11ee-be56-0242ac120002"))
+                .body("filters[0]['name']", equalTo("Assigned Users"))
+                .body("filters[0]['id']", equalTo("assignedUsers"))
+                .body("filters[0]['items'][0]['id']", equalTo("8f69def4-3c52-11ee-be56-0242ac120002"))
+                .body("filters[0]['items'][0]['name']", equalTo("John Smith"))
+                .body("filters[0]['items'][0]['active']", equalTo(true))
+                .body("filters[2]['id']", equalTo("states"))
+                .body("filters[2]['name']", equalTo("Hearing Outcome States"))
+                .body("filters[2]['items'][0]['id']", equalTo("NEW"))
+                .body("filters[2]['items'][0]['matches']", equalTo(0))
+                .body("filters[2]['items'][1]['id']", equalTo("IN_PROGRESS"))
+                .body("filters[2]['items'][1]['matches']", equalTo(2))
+    }
+
+    @Test
+    fun `given court code and outcome state IN_PROGRESS and assigned to user, should return outcomes correctly`() {
+
+        val courtCode = "B10JQ"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+                .queryParam("state", "IN_PROGRESS")
+                .queryParam("assignedUsers", listOf("4b03d065-4c96-4b24-8d6d-75a45d2e3f12"))
+                .build().toUriString()
+
+        given()
+                .auth()
+                .oauth2(TokenHelper.getToken())
+                .accept(ContentType.JSON)
+                .`when`()
+                .get(endpoint)
+                .then()
+                .statusCode(200)
+                .body("records", hasSize<Any>(1))
+                .body("records[0].hearingOutcomeType", equalTo("ADJOURNED"))
+                .body("records[0].outcomeDate", equalTo("2023-04-24T09:09:09"))
+                .body("records[0].hearingId", equalTo("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636"))
+                .body("records[0].hearingDate", equalTo("2019-12-14"))
+                .body("records[0].defendantId", equalTo("40db17d6-04db-11ec-b2d8-0242ac130002"))
+                .body("records[0].defendantName", equalTo("Mr Johnny BALL"))
+                .body("records[0].probationStatus", equalTo("Current"))
+                .body("records[0].assignedTo", equalTo("Joe Blogs"))
+                .body("records[0].assignedToUuid", equalTo("4b03d065-4c96-4b24-8d6d-75a45d2e3f12"))
+                .body("records[0].state", equalTo("IN_PROGRESS"))
+    }
+
+    @Test
+    fun `given court code and assigned user then return all outcomes assigned to that user`() {
+
+        val courtCode = "B10JQ"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+            .queryParam("assignedUsers", listOf("4b03d065-4c96-4b24-8d6d-75a45d2e3f12"))
+            .build().toUriString()
+
+        given()
+            .auth()
+            .oauth2(TokenHelper.getToken())
+            .accept(ContentType.JSON)
+            .`when`()
+            .get(endpoint)
+            .then()
+            .statusCode(200)
+            .body("records", hasSize<Any>(1))
+            .body("records[0].hearingOutcomeType", equalTo("ADJOURNED"))
+            .body("records[0].outcomeDate", equalTo("2023-04-24T09:09:09"))
+            .body("records[0].hearingId", equalTo("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636"))
+            .body("records[0].hearingDate", equalTo("2019-12-14"))
+            .body("records[0].defendantId", equalTo("40db17d6-04db-11ec-b2d8-0242ac130002"))
+            .body("records[0].defendantName", equalTo("Mr Johnny BALL"))
+            .body("records[0].crn", equalTo("X320741"))
+            .body("records[0].probationStatus", equalTo("Current"))
+            .body("records[0].assignedTo", equalTo("Joe Blogs"))
+            .body("records[0].assignedToUuid", equalTo("4b03d065-4c96-4b24-8d6d-75a45d2e3f12"))
+    }
+
+    @Test
+    fun `given court code and outcome state NEW and filters do not match, it should return an empty response`() {
+
+        val courtCode = "B33HU"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+            .queryParam("state", "NEW")
+            .queryParam("outcomeTypes",  "PROBATION_SENTENCE", "REPORT_REQUESTED")
+            .build().toUriString()
+
+        given()
+            .auth()
+            .oauth2(TokenHelper.getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(HEARING_OUTCOME_REQUEST)
+            .`when`()
+            .get(endpoint)
+            .then()
+            .statusCode(200)
+            .header("X-PAGINATION-CURRENT-PAGE", equalTo("1"))
+            .header("X-PAGINATION-PAGE-SIZE", equalTo("20"))
+            .header("X-PAGINATION-TOTAL-PAGES", equalTo("0"))
+            .header("X-PAGINATION-TOTAL-RESULTS", equalTo("0"))
+            .body("records", hasSize<Any>(0))
+            .body("filters[0]['name']", equalTo("Assigned Users"))
+            .body("filters[0]['id']", equalTo("assignedUsers"))
+            .body("filters[0]['items']", hasSize<Any>(0))
+            .body("filters[1]['id']", equalTo("courtRooms"))
+            .body("filters[1]['items']", hasSize<Any>(1))
+            .body("filters[1]['items'][0]['id']", equalTo("2"))
+            .body("filters[2]['id']", equalTo("states"))
+            .body("filters[2]['name']", equalTo("Hearing Outcome States"))
+            .body("filters[2]['items'][0]['id']", equalTo("NEW"))
+            .body("filters[2]['items'][0]['matches']", equalTo(1))
+            .body("filters[2]['items'][1]['id']", equalTo("IN_PROGRESS"))
+            .body("filters[2]['items'][1]['matches']", equalTo(0))
+    }
+
+    @Test
+    fun `given court code, soryBy and order, it should return all hearing defendant outcomes in hearingDate sort and descending order`(){
+
+        val courtCode = "B10JQ"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+            .queryParam("sortBy",  "hearingDate")
+            .queryParam("order",  "DESC")
+            .build().toUriString()
+
+        given()
+            .auth()
+            .oauth2(TokenHelper.getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .`when`()
+            .get(endpoint)
+            .then()
+            .statusCode(200)
+            .header("X-PAGINATION-CURRENT-PAGE", equalTo("1"))
+            .header("X-PAGINATION-PAGE-SIZE", equalTo("20"))
+            .header("X-PAGINATION-TOTAL-PAGES", equalTo("1"))
+            .header("X-PAGINATION-TOTAL-RESULTS", equalTo("2"))
+            .body("records", hasSize<Any>(2))
+            .body("records[0].hearingDate", equalTo("2019-12-14"))
+            .body("records[1].hearingDate", equalTo("2019-11-14"))
+    }
+
+    @Test
+    fun `given court code, soryBy and order, it should return all hearing defendant outcomes in hearingDate sort and ascending order`(){
+
+        val courtCode = "B10JQ"
+
+        val endpoint = UriComponentsBuilder.fromUri(URI("v2/courts/${courtCode}/hearing-defendant-outcomes"))
+            .queryParam("sortBy",  "hearingDate")
+            .queryParam("order",  "ASC")
+            .build().toUriString()
+
+        given()
+            .auth()
+            .oauth2(TokenHelper.getToken())
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .`when`()
+            .get(endpoint)
+            .then()
+            .statusCode(200)
+            .header("X-PAGINATION-CURRENT-PAGE", equalTo("1"))
+            .header("X-PAGINATION-PAGE-SIZE", equalTo("20"))
+            .header("X-PAGINATION-TOTAL-PAGES", equalTo("1"))
+            .header("X-PAGINATION-TOTAL-RESULTS", equalTo("2"))
+            .body("records", hasSize<Any>(2))
+            .body("records[0].hearingDate", equalTo("2019-11-14"))
+            .body("records[1].hearingDate", equalTo("2019-12-14"))
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomIntTest.kt
@@ -32,9 +32,10 @@ internal class HearingOutcomeRepositoryCustomIntTest {
 
     @Test
     fun `should return outcomes resulted within last 14 days`() {
-        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest(state = RESULTED))
-        assertThat(result.content.size).isEqualTo(1)
-        assertThat(result.content[0].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
+        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest(
+            state = RESULTED))
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
     }
 
     @Test
@@ -47,8 +48,8 @@ internal class HearingOutcomeRepositoryCustomIntTest {
             HearingOutcomeSearchRequest(state = RESULTED, courtRoom = listOf("1", "3")))
 
         // Then
-        assertThat(result.content.size).isEqualTo(2)
-        assertThat(result.content).extracting("first.hearing.hearingId").containsExactlyInAnyOrder("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636", "1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result).extracting("first.hearing.hearingId").containsExactlyInAnyOrder("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636", "1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
     }
 
     @TestConfiguration

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomPaginationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomPaginationIntTest.kt
@@ -12,7 +12,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState.IN_PROGRESS
-import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState.RESULTED
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSearchRequest
 
 @DataJpaTest
@@ -29,24 +28,22 @@ internal class HearingOutcomeRepositoryCustomPaginationIntTest {
     lateinit var hearingOutcomeRepositoryCustom: HearingOutcomeRepositoryCustom
 
     @Test
-    fun `should return outcomes 1st page results`() {
-        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest(state = IN_PROGRESS, page = 1, size = 2))
-        assertThat(result.content.size).isEqualTo(2)
-        assertThat(result.content[0].first.hearing.hearingId).isEqualTo("2aa6f5e0-f842-4939-bc6a-01346abc09e7")
-        assertThat(result.content[1].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
-        assertThat(result.size).isEqualTo(2)
-        assertThat(result.totalPages).isEqualTo(2)
-        assertThat(result.totalElements).isEqualTo(3)
+    fun `given court code it should return all HearingDefendants with outcomes for this court`() {
+        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest())
+        assertThat(result.size).isEqualTo(3)
+        assertThat(result[0].first.hearing.hearingId).isEqualTo("2aa6f5e0-f842-4939-bc6a-01346abc09e7")
+        assertThat(result[1].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
+        assertThat(result[2].first.hearing.hearingId).isEqualTo("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636")
     }
 
     @Test
-    fun `should return outcomes 2nd page results`() {
-        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest(state = IN_PROGRESS, page = 2, size = 2))
-        assertThat(result.content.size).isEqualTo(1)
-        assertThat(result.content[0].first.hearing.hearingId).isEqualTo("ddfe6b75-c3fc-4ed0-9bf6-21d66b125636")
-        assertThat(result.size).isEqualTo(2)
-        assertThat(result.totalPages).isEqualTo(2)
-        assertThat(result.totalElements).isEqualTo(3)
+    fun `given court code and search filters it should return filtered HearingDefendants with outcomes for this court`() {
+        val result = hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome("B10JQ", HearingOutcomeSearchRequest(
+            state = IN_PROGRESS, assignedToUuid = listOf("8f69def4-3c52-11ee-be56-0242ac120002")))
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].first.hearingOutcome.assignedTo).isEqualTo("John Smith")
+        assertThat(result[0].first.hearingOutcome.assignedToUuid).isEqualTo("8f69def4-3c52-11ee-be56-0242ac120002")
+        assertThat(result[0].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
     }
 
     @TestConfiguration

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/CaseWorkflowServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/CaseWorkflowServiceIntTest.kt
@@ -1,9 +1,8 @@
 package uk.gov.justice.probation.courtcaseservice.service
 
-import org.junit.jupiter.api.Assertions.*
-
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -15,7 +14,10 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeCaseList
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState
+import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSearchRequest
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingOutcomeAssignedUser
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtRepository
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.HearingOutcomeRepositoryCustom
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.HearingRepository
@@ -94,6 +96,20 @@ internal class CaseWorkflowServiceIntTest {
         assertThat(hearingOutcomeEntity.outcomeType).isEqualTo(HearingOutcomeType.NO_OUTCOME.name)
         assertThat(hearingOutcomeEntity.state).isEqualTo(HearingOutcomeItemState.NEW.name)
 
+    }
+
+    @Test
+    fun shouldReturnListOfHearingOutcomesForCourt(){
+        val hearingOutcomeSearchRequest: HearingOutcomeSearchRequest = HearingOutcomeSearchRequest(page = 1, size = 1)
+        val hearingOutcomesCaseList: HearingOutcomeCaseList = caseWorkflowService.fetchHearingOutcomes("B10JQ", hearingOutcomeSearchRequest)
+
+        assertAll("hearingOutcomesCaseList",
+            { assertThat(hearingOutcomesCaseList.assignedUsers).contains(HearingOutcomeAssignedUser("Jane Doe", "4b03d065-4c96-4b24-8d6d-75a45d2e3f12")) },
+            { assertThat(hearingOutcomesCaseList.page).isEqualTo(1)},
+            { assertThat(hearingOutcomesCaseList.cases[0].hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00") },
+            { assertThat(hearingOutcomesCaseList.cases[0].assignedTo).isEqualTo("Jane Doe") },
+            { assertThat(hearingOutcomesCaseList.cases).hasSize(1) }
+        )
     }
 
     @org.springframework.boot.test.context.TestConfiguration

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/CaseWorkflowServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/CaseWorkflowServiceTest.kt
@@ -6,15 +6,17 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
+import org.mockito.BDDMockito
 import org.mockito.BDDMockito.*
 import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import org.springframework.web.client.HttpClientErrorException
 import uk.gov.justice.probation.courtcaseservice.controller.model.*
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCountByState as V2HearingOutcomeCountByState
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingDefendantOutcomesRequest
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCaseList as V2HearingOutcomeCaseList
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.*
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.*
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtRepository
@@ -146,15 +148,15 @@ internal class CaseWorkflowServiceTest {
 
         // Then
         verify(hearingRepository).findFirstByHearingId(hearingId)
-        verify(hearingRepository, never()).save(any())
+        verify(hearingRepository, never()).save(org.mockito.kotlin.any())
     }
 
     @Test
     fun `given court code and outcome type filter invoke repository and return hearing outcomes`() {
         val hearingOutcomeEntity1 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.REPORT_REQUESTED.name).outcomeDate(
-            LocalDateTime.of(2023, 6,6, 19, 9, 1)).state("NEW").build()
+            LocalDateTime.of(2023, 6,6, 19, 9, 1)).state("NEW").assignedTo("Jane Doe").assignedToUuid("fake-uuid").build()
         val hearingOutcomeEntity2 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.ADJOURNED.name).outcomeDate(
-            LocalDateTime.of(2023, 5,5, 19, 9, 5)).state("NEW").build()
+            LocalDateTime.of(2023, 5,5, 19, 9, 5)).state("NEW").assignedTo("John Doe").assignedToUuid("fake-uuid").build()
 
         val hearingId1 = "hearing-id-1"
         val defendantId1 = "defendant-id-1"
@@ -177,20 +179,17 @@ internal class CaseWorkflowServiceTest {
         refreshMappings(hearing2)
 
         given(courtRepository.findByCourtCode(COURT_CODE)).willReturn(Optional.of(CourtEntity.builder().build()))
-        given(
+        lenient().`when`(
             hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome(
-                COURT_CODE,
-                HearingOutcomeSearchRequest(HearingOutcomeItemState.NEW)
+                org.mockito.kotlin.eq(COURT_CODE),
+                org.mockito.kotlin.any()
+
             )
-        ).willReturn(
-            PageImpl(
+        ).thenReturn(
                 listOf(
                     Pair<HearingDefendantEntity, LocalDate>(hearingDefendant1, SESSION_START_TIME.toLocalDate()),
                     Pair<HearingDefendantEntity, LocalDate>(hearingDefendant2, SESSION_START_TIME.toLocalDate())
-                ),
-                Pageable.ofSize(2),
-                9
-            )
+                )
         )
 
         given(hearingRepository.getCourtroomsForCourt(COURT_CODE)).willReturn(TEST_COURT_ROOMS)
@@ -210,6 +209,8 @@ internal class CaseWorkflowServiceTest {
                         offences = listOf(OFFENCE_TITLE),
                         defendantName = DEFENDANT_NAME,
                         crn = "X340906",
+                        assignedTo = "Jane Doe",
+                        assignedToUuid = "fake-uuid",
                         state = HearingOutcomeItemState.NEW
                     ),
                     HearingOutcomeResponse(
@@ -222,16 +223,208 @@ internal class CaseWorkflowServiceTest {
                         offences = listOf(OFFENCE_TITLE),
                         defendantName = DEFENDANT_NAME,
                         crn = "X340906",
+                        assignedTo = "John Doe",
+                        assignedToUuid = "fake-uuid",
                         state = HearingOutcomeItemState.NEW
                     )
                 ),
                 hearingOutcomes.countsByState,
                 TEST_COURT_ROOMS,
-                        5,
                         1,
-                        9
+                        1,
+                        2,
+                listOf(HearingOutcomeAssignedUser("Jane Doe", "fake-uuid"), HearingOutcomeAssignedUser("John Doe", "fake-uuid"))
             )
         )
+    }
+
+    @Test
+    fun `v2 endpoint, given court code and outcome type filter invoke repository and return hearing outcomes`(){
+        val hearingOutcomeEntity1 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.REPORT_REQUESTED.name).outcomeDate(
+            LocalDateTime.of(2023, 6,6, 19, 9, 1)).state("NEW").assignedTo("Jane Doe").assignedToUuid("fake-uuid").build()
+        val hearingOutcomeEntity2 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.ADJOURNED.name).outcomeDate(
+            LocalDateTime.of(2023, 5,5, 19, 9, 5)).state("NEW").assignedTo("John Doe").assignedToUuid("fake-uuid").build()
+
+        val hearingId1 = "hearing-id-1"
+        val defendantId1 = "defendant-id-1"
+        val caseId1 = "case-id-1"
+        val hearingId2 = "hearing-id-2"
+        val caseId2 = "case-id-2"
+        val defendantId2 = "defendant-id-2"
+
+        aHearingEntityWithHearingId(caseId1, hearingId1, defendantId1);
+        val hearingDefendant1 = aHearingDefendantEntity(defendantId1).withHearingOutcome(hearingOutcomeEntity1)
+
+        val hearing1 = aHearingEntityWithHearingId(caseId1, hearingId1, defendantId1)
+            .withHearingDefendants(listOf(hearingDefendant1))
+
+        val hearingDefendant2 = aHearingDefendantEntity(defendantId2).withHearingOutcome(hearingOutcomeEntity2)
+        val hearing2 = aHearingEntityWithHearingId(caseId2, hearingId2, defendantId2)
+            .withHearingDefendants(listOf(hearingDefendant2))
+
+        refreshMappings(hearing1)
+        refreshMappings(hearing2)
+
+        given(courtRepository.findByCourtCode(COURT_CODE)).willReturn(Optional.of(CourtEntity.builder().build()))
+
+        lenient().`when`(hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome(
+            org.mockito.kotlin.eq(COURT_CODE),
+            org.mockito.kotlin.any()
+        )).thenReturn(
+            listOf(
+                Pair<HearingDefendantEntity, LocalDate>(hearingDefendant1, SESSION_START_TIME.toLocalDate()),
+                Pair<HearingDefendantEntity, LocalDate>(hearingDefendant2, SESSION_START_TIME.toLocalDate())
+            )
+        )
+
+        given(hearingRepository.getCourtroomsForCourt(COURT_CODE)).willReturn(TEST_COURT_ROOMS)
+
+        val hearingOutcomes = caseWorkflowService.fetchV2HearingDefendantOutcomes(COURT_CODE, HearingDefendantOutcomesRequest())
+
+        assertThat(hearingOutcomes).isEqualTo(
+            V2HearingOutcomeCaseList(
+                records = listOf(
+                    HearingOutcomeResponse(
+                        hearingOutcomeType = HearingOutcomeType.REPORT_REQUESTED,
+                        outcomeDate = LocalDateTime.of(2023, 6, 6, 19, 9, 1),
+                        hearingDate = SESSION_START_TIME.toLocalDate(),
+                        hearingId = hearingId1,
+                        defendantId = defendantId1,
+                        probationStatus = PROBATION_STATUS,
+                        offences = listOf(OFFENCE_TITLE),
+                        defendantName = DEFENDANT_NAME,
+                        crn = "X340906",
+                        assignedTo = "Jane Doe",
+                        assignedToUuid = "fake-uuid",
+                        state = HearingOutcomeItemState.NEW
+                    ),
+                    HearingOutcomeResponse(
+                        hearingOutcomeType = HearingOutcomeType.ADJOURNED,
+                        outcomeDate = LocalDateTime.of(2023, 5, 5, 19, 9, 5),
+                        hearingDate = SESSION_START_TIME.toLocalDate(),
+                        hearingId = hearingId2,
+                        defendantId = defendantId2,
+                        probationStatus = PROBATION_STATUS,
+                        offences = listOf(OFFENCE_TITLE),
+                        defendantName = DEFENDANT_NAME,
+                        crn = "X340906",
+                        assignedTo = "John Doe",
+                        assignedToUuid = "fake-uuid",
+                        state = HearingOutcomeItemState.NEW
+                    )
+                ),
+                countsByState = V2HearingOutcomeCountByState(counts = listOf(Pair("NEW", 0), Pair("IN_PROGRESS", 0), Pair("RESULTED", 0))),
+                courtRoomFilters = listOf("01", "Court room - 2"),
+                totalPages = 1,
+                page = 1,
+                totalElements =  2,
+                assignedUsers = listOf(HearingOutcomeAssignedUser("Jane Doe", "fake-uuid"), HearingOutcomeAssignedUser("John Doe", "fake-uuid"))
+            )
+        )
+    }
+
+    @Test
+    fun `given court code and page size filter invoke repository and return hearing outcomes for page 1 of 2`(){
+        val hearingOutcomeEntity1 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.REPORT_REQUESTED.name).outcomeDate(
+            LocalDateTime.of(2023, 6,6, 19, 9, 1)).state("IN_PROGRESS").assignedTo("Jane Doe").assignedToUuid("fake-uuid").build()
+        val hearingOutcomeEntity2 = HearingOutcomeEntity.builder().outcomeType(HearingOutcomeType.ADJOURNED.name).outcomeDate(
+            LocalDateTime.of(2023, 5,5, 19, 9, 5)).state("IN_PROGRESS").assignedTo("John Doe").assignedToUuid("fake-uuid").build()
+
+        val hearingId1 = "hearing-id-1"
+        val defendantId1 = "defendant-id-1"
+        val caseId1 = "case-id-1"
+        val hearingId2 = "hearing-id-2"
+        val caseId2 = "case-id-2"
+        val defendantId2 = "defendant-id-2"
+
+        aHearingEntityWithHearingId(caseId1, hearingId1, defendantId1);
+        val hearingDefendant1 = aHearingDefendantEntity(defendantId1).withHearingOutcome(hearingOutcomeEntity1)
+
+        val hearing1 = aHearingEntityWithHearingId(caseId1, hearingId1, defendantId1)
+            .withHearingDefendants(listOf(hearingDefendant1))
+
+        val hearingDefendant2 = aHearingDefendantEntity(defendantId2).withHearingOutcome(hearingOutcomeEntity2)
+        val hearing2 = aHearingEntityWithHearingId(caseId2, hearingId2, defendantId2)
+            .withHearingDefendants(listOf(hearingDefendant2))
+
+        refreshMappings(hearing1)
+        refreshMappings(hearing2)
+
+        given(courtRepository.findByCourtCode(COURT_CODE)).willReturn(Optional.of(CourtEntity.builder().build()))
+        val filterOptions = HearingOutcomeSearchRequest(HearingOutcomeItemState.IN_PROGRESS, page = 1, size = 1)
+        given(
+            hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome(
+                COURT_CODE,
+                filterOptions
+            )
+        ).willReturn(
+            listOf(
+                Pair<HearingDefendantEntity, LocalDate>(hearingDefendant1, SESSION_START_TIME.toLocalDate()),
+                Pair<HearingDefendantEntity, LocalDate>(hearingDefendant2, SESSION_START_TIME.toLocalDate())
+            )
+        )
+
+        given(hearingRepository.getCourtroomsForCourt(COURT_CODE)).willReturn(TEST_COURT_ROOMS)
+
+        val hearingOutcomes = caseWorkflowService.fetchHearingOutcomes(COURT_CODE, filterOptions)
+
+        assertThat(hearingOutcomes).isEqualTo(
+            HearingOutcomeCaseList(
+                listOf(
+                    HearingOutcomeResponse(
+                        hearingOutcomeType = HearingOutcomeType.REPORT_REQUESTED,
+                        outcomeDate = LocalDateTime.of(2023, 6, 6, 19, 9, 1),
+                        hearingDate = SESSION_START_TIME.toLocalDate(),
+                        hearingId = hearingId1,
+                        defendantId = defendantId1,
+                        probationStatus = PROBATION_STATUS,
+                        offences = listOf(OFFENCE_TITLE),
+                        defendantName = DEFENDANT_NAME,
+                        crn = "X340906",
+                        assignedTo = "Jane Doe",
+                        assignedToUuid = "fake-uuid",
+                        state = HearingOutcomeItemState.IN_PROGRESS
+                    )
+                ),
+                hearingOutcomes.countsByState,
+                TEST_COURT_ROOMS,
+                2,
+                1,
+                2,
+                listOf(HearingOutcomeAssignedUser("Jane Doe", "fake-uuid"), HearingOutcomeAssignedUser("John Doe", "fake-uuid"))
+            )
+        )
+    }
+
+    @Test
+    fun `given hearingOutcomeResponse and search filters when getting pageable hearing outcomes then provide pagination`(){
+        var hearingOutcomeResponseList: ArrayList<HearingOutcomeResponse> = ArrayList();
+
+        for (i in 1..3) {
+            hearingOutcomeResponseList.add(
+                HearingOutcomeResponse(
+                    HearingOutcomeType.NO_OUTCOME,
+                    outcomeDate = LocalDateTime.parse("2023-04-24T09:09:09"),
+                    resultedDate = LocalDateTime.parse("2024-04-12T00:00:00"),
+                    hearingDate=LocalDate.parse("2024-04-11"),
+                    hearingId="1f93aa0a-7e46-4885-a1cb-f25a4be33a00",
+                    defendantId = "40db17d6-04db-11ec-b2d8-0242ac130002",
+                    probationStatus="Current",
+                    offences= listOf("Theft from a different shop, Theft from a shop"),
+                    defendantName="Mr Johnny BALL",
+                    crn="crn-${i}",
+                    assignedTo="Jane Doe",
+                    assignedToUuid="4b03d065-4c96-4b24-8d6d-75a45d2e3f12",
+                    state=HearingOutcomeItemState.NEW,
+                    legacy=false
+                )
+            )
+        }
+        val searchRequest: HearingOutcomeSearchRequest = HearingOutcomeSearchRequest(page = 3, size = 1)
+        val page = caseWorkflowService.getPageableHearingOutcomes(hearingOutcomeResponseList.toList(), searchRequest)
+        assertThat(page.number).isEqualTo(2) // pageable numbers start from 0
+        assertThat(page.totalPages).isEqualTo(3)
+        assertThat(page.content[0].crn).isEqualTo("crn-3")
     }
 
     @Test
@@ -459,4 +652,9 @@ internal class CaseWorkflowServiceTest {
         verify(hearingRepository).save(aHearingEntity)
         verifyNoMoreInteractions(hearingRepository)
     }
+
+//    @Test
+//    fun 'hearing outcomes and hearingOutcomeSearchRequest, it returns the paginated sublist of hearing outcomes'(){
+//
+//    }
 }

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/PaginatedHeadersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/PaginatedHeadersServiceTest.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.probation.courtcaseservice.service
+
+import net.javacrumbs.jsonunit.assertj.assertThatJson
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.HttpHeaders
+
+@ExtendWith(MockitoExtension::class)
+class PaginatedHeadersServiceTest {
+
+
+    lateinit var paginatedHeadersService: PaginatedHeadersService
+    @BeforeEach
+    fun initTest() {
+        paginatedHeadersService = PaginatedHeadersService()
+    }
+
+    @Test
+    fun `given pagination data, it returns a HTTPHeader with custom pagination headers`(){
+
+        val headers: HttpHeaders = paginatedHeadersService.getHeaders(1, 2, 2, 4)
+
+        assertThat(headers["X-PAGINATION-CURRENT-PAGE"]).contains("1")
+        assertThat(headers["X-PAGINATION-PAGE-SIZE"]).contains("2")
+        assertThat(headers["X-PAGINATION-TOTAL-PAGES"]).contains("2")
+        assertThat(headers["X-PAGINATION-TOTAL-RESULTS"]).contains("4")
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesServiceTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.probation.courtcaseservice.service.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.justice.probation.courtcaseservice.controller.CaseWorkflowControllerTest
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.FilterItem
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.FilteredHearingDefendantOutcomesResponse
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.FiltersList
+import uk.gov.justice.probation.courtcaseservice.controller.model.filters.HearingOutcomeStatesFilterItem
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCountByState
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.HearingOutcomeAssignedUser
+import uk.gov.justice.probation.courtcaseservice.controller.model.v2.HearingOutcomeCaseList as V2HearingOutcomeCaseList
+
+@ExtendWith(MockitoExtension::class)
+class FilterHearingDefendantOutcomesServiceTest {
+
+    @Mock
+    lateinit var hearingDefendantOutcomesCaseList: V2HearingOutcomeCaseList
+
+    private lateinit var service: FilterHearingDefendantOutcomesService
+    @BeforeEach
+    fun initTest() {
+        hearingDefendantOutcomesCaseList =
+            V2HearingOutcomeCaseList(
+                listOf(),
+                HearingOutcomeCountByState(listOf(Pair("NEW", 1), Pair("IN_PROGRESS",0), Pair("Resulted", 2))),
+                CaseWorkflowControllerTest.TEST_COURT_ROOMS,
+                1,
+                1,
+                1,
+                listOf<HearingOutcomeAssignedUser>(HearingOutcomeAssignedUser("John Doe", "UUID"))
+            )
+        service = FilterHearingDefendantOutcomesService(hearingDefendantOutcomesCaseList)
+    }
+
+    @Test
+    fun `getResponse provides the filters available for hearing defendant outcomes`(){
+        val result: FilteredHearingDefendantOutcomesResponse = service.getResponse()
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(FilteredHearingDefendantOutcomesResponse(hearingDefendantOutcomesCaseList.records,
+            mutableListOf(
+                FiltersList("assignedUsers", "Assigned Users", true, listOf(FilterItem("UUID", "John Doe", true))),
+                FiltersList("courtRooms", "Court Rooms", true, listOf(FilterItem("01", "01", true), FilterItem("Court room - 2", "Court room - 2", true))),
+                FiltersList("states", "Hearing Outcome States", true, listOf(HearingOutcomeStatesFilterItem("NEW", "New", 1, true ), HearingOutcomeStatesFilterItem("IN_PROGRESS", "In Progress", 0, true ), HearingOutcomeStatesFilterItem("RESULTED", "Resulted", 0, true)))
+            )
+        ))
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/service/v2/FilterHearingDefendantOutcomesServiceTest.kt
@@ -48,7 +48,7 @@ class FilterHearingDefendantOutcomesServiceTest {
             mutableListOf(
                 FiltersList("assignedUsers", "Assigned Users", true, listOf(FilterItem("UUID", "John Doe", true))),
                 FiltersList("courtRooms", "Court Rooms", true, listOf(FilterItem("01", "01", true), FilterItem("Court room - 2", "Court room - 2", true))),
-                FiltersList("states", "Hearing Outcome States", true, listOf(HearingOutcomeStatesFilterItem("NEW", "New", 1, true ), HearingOutcomeStatesFilterItem("IN_PROGRESS", "In Progress", 0, true ), HearingOutcomeStatesFilterItem("RESULTED", "Resulted", 0, true)))
+                FiltersList("states", "Hearing Outcome States", false, listOf(HearingOutcomeStatesFilterItem("NEW", "New", 1, true ), HearingOutcomeStatesFilterItem("IN_PROGRESS", "In Progress", 0, true ), HearingOutcomeStatesFilterItem("RESULTED", "Resulted", 0, true)))
             )
         ))
     }

--- a/src/test/resources/sql/hearing-outcomes-unresulted-cases.sql
+++ b/src/test/resources/sql/hearing-outcomes-unresulted-cases.sql
@@ -48,7 +48,7 @@ INSERT INTO courtcaseservicetest.hearing_outcome(id, outcome_type, outcome_date,
 VALUES (-1710020001, 'ADJOURNED', '2023-4-24 09:09:09', 'RESULTED', now() - interval '15 days', now(), 'case-progress.sql', 'Joe Blogs', '4b03d065-4c96-4b24-8d6d-75a45d2e3f12', -1000110);
 
 INSERT INTO courtcaseservicetest.hearing_outcome(id, outcome_type, outcome_date, state, resulted_date, created, created_by, assigned_to, assigned_to_uuid, fK_hearing_defendant_id)
-VALUES (-1710020002, 'NO_OUTCOME', '2023-4-24 09:09:09', 'NEW', now() - interval '15 days', now(), 'case-progress.sql', 'Joe Blogs', '4b03d065-4c96-4b24-8d6d-75a45d2e3f12', -1000000);
+VALUES (-1710020002, 'NO_OUTCOME', '2023-4-24 09:09:09', 'NEW', now() - interval '15 days', now(), 'case-progress.sql', 'Jane Doe', '4b03d065-4c96-4b24-8d6d-75a45d2e3f12', -1000000);
 
 
 


### PR DESCRIPTION
## Return all Assigned Users for court

**Tickets**:

[V2 endpoint](https://dsdmoj.atlassian.net/browse/PIC-3808)
[Bug fix assigned uesrs](https://dsdmoj.atlassian.net/browse/PIC-3725)

**Bug Fix:**

The user requirements did not want assigned users to be paginated

- Return all `assignedUsers` property for GET `/courts/{courtcode}/hearing-outcomes` which has all the assigned users on hearing-outcomes with no pagination
- do the same for the v2 endpoint

**Change Pagination:**

- Remove pagination from `HearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome` and return all the filtered results

- Get all assigned users without pagination.
    - This came after removing pagination from `hearingOutcomeRepositoryCustom.findByCourtCodeAndHearingOutcome`

- Return assignedUsers in `HearingOutcomeCaseList` for function `CaseWorkflowService#fetchHearingOutcomes`

- Include pagination `CaseWorkflowService` to continue providing a paginated set of hearing outcomes as part of `HearingOutcomeCaseList`


**Create version 2 endpoint to return hearing defendant outcomes**
- Create a V2 endpoint for hearing outcomes GET `/v2/courts/{courtcode}/hearing-defendant-outcomes`
- [example_v2_response.json](https://github.com/ministryofjustice/court-case-service/files/15146702/example_v2_response.json)



