### PR TITLE
Reintroduce data-dictionary 

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -36,24 +36,21 @@ nginx_proxy:
       pullPolicy: Always
     port: 8080
 
-# TODO - data-dictionary nginx fails currently blocking deployment of court-case-service too.
-#  Fix this issue and uncomment below entries for data-dictionary to deploy.
-#  data-dictionary is only used in dev env by analytics team.
-#data_dictionary:
-#  name: pic-data-dictionary
-#  service_host: http://pic-data-dictionary.pic-data-dictionary
-#  replicaCount: 1
-#
-#  service:
-#    port:
-#      http: 80
-#
-#  deployment:
-#    image:
-#      repository: quay.io/hmpps/pic-data-dictionary
-#      tag: latest
-#      pullPolicy: Always
-#    port: 8080
+data_dictionary:
+  name: pic-data-dictionary
+  service_host: http://pic-data-dictionary.pic-data-dictionary
+  replicaCount: 1
+
+  service:
+    port:
+      http: 80
+
+  deployment:
+    image:
+      repository: quay.io/hmpps/pic-data-dictionary
+      tag: latest
+      pullPolicy: Always
+    port: 8080
 
 hearing_outcomes:
   process_un_resulted_cases_cron: "30 12-20 * * *"


### PR DESCRIPTION
Reintroduce data-dictionary ([schemaspy](https://schemaspy.org/))

This allows the analytics team and members of the probation in court team to view the database schema in a user friendly UI.


**Related PR:**
[This PR removed it temporarily](https://github.com/ministryofjustice/court-case-service/pull/1160)
