### PR TITLE
Deployment Fix: Resolve permission issues for data-dictionary deployment

### DIFF
--- a/helm_deploy/court-case-service/templates/data-dictionary-deployment.yaml
+++ b/helm_deploy/court-case-service/templates/data-dictionary-deployment.yaml
@@ -22,6 +22,9 @@ spec:
     spec:
       securityContext:
         runAsUser: 101
+        add:
+          - NET_BIND_SERVICE
+        allowPrivilegeEscalation: false
       containers:
         - name: data-dictionary
           image: "{{ .Values.data_dictionary.deployment.image.repository }}:{{ .Values.data_dictionary.deployment.image.tag }}"


### PR DESCRIPTION
#### Deployment Fix: Resolve permission issues for data-dictionary deployment

Allow the k8s data-dictionary deployment to bind to the k8s service

why?
Alpinelinux uses User 101 hence why we have runAsUser: 101. This does not currently have the permissions to bind to port 80 (which is where the ingress is running on)

Fixes the error:

`nginx: [emerg] bind() to 0.0.0.0:80 failed (13: Permission denied)`