### PR TITLE
Fix data dictionary kubernetes config format

### DIFF
--- a/helm_deploy/court-case-service/templates/data-dictionary-deployment.yaml
+++ b/helm_deploy/court-case-service/templates/data-dictionary-deployment.yaml
@@ -22,8 +22,9 @@ spec:
     spec:
       securityContext:
         runAsUser: 101
-        add:
-          - NET_BIND_SERVICE
+        capabilities:
+          add:
+            - NET_BIND_SERVICE
         allowPrivilegeEscalation: false
       containers:
         - name: data-dictionary


### PR DESCRIPTION
#### Fix kubernetes formatting for data dictionary deployment


adding the port binding capability to user 101, it should be under the `capabilities` property