### PR TITLE
Deployment Fix: Change data-dictionary service port name to be unique

### DIFF
--- a/helm_deploy/court-case-service/templates/data-dictionary-service.yaml
+++ b/helm_deploy/court-case-service/templates/data-dictionary-service.yaml
@@ -15,7 +15,7 @@ spec:
     - port: {{ .Values.data_dictionary.service.port.http }}
       targetPort: {{ .Values.data_dictionary.deployment.port }}
       protocol: TCP
-      name: http
+      name: {{ .Values.data_dictionary.name }}-http
   selector:
     app: {{ .Values.data_dictionary.name }}
 

--- a/helm_deploy/court-case-service/templates/nginx-service.yaml
+++ b/helm_deploy/court-case-service/templates/nginx-service.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
-      port: {{ .Values.nginx_proxy.service.port.http }}
+    - port: {{ .Values.nginx_proxy.service.port.http }}
       targetPort: {{ .Values.nginx_proxy.deployment.port }}
       protocol: TCP
+      name: {{ .Values.nginx_proxy.name }}-http
   selector:
     app: {{ .Values.nginx_proxy.name }}


### PR DESCRIPTION
#### Change K8s Service port names to be unique


This should fix the deployment issue for data dictionary:

`Error: UPGRADE FAILED: cannot patch [data dictionary service] with kind Service: Service  [data dictionary service]  is invalid: spec.ports[1].name: Duplicate value: "http"`

