### PR TITLE
Deployment Fix: Set data-dictionary nginx to listen on port 8080

### DIFF
--- a/data_dictionary/Dockerfile
+++ b/data_dictionary/Dockerfile
@@ -10,4 +10,4 @@ RUN apk upgrade --no-cache
 COPY /nginx.conf /etc/nginx/
 COPY schema/ /usr/share/nginx/html/meta/schema
 
-EXPOSE 8080
+EXPOSE 8081

--- a/data_dictionary/default.conf.template
+++ b/data_dictionary/default.conf.template
@@ -1,7 +1,7 @@
 
 server {
-    listen       8080;
-    listen  [::]:8080;
+    listen       8081;
+    listen  [::]:8081;
     server_name  localhost;
 
     add_header X-Cache-Status $upstream_cache_status;

--- a/data_dictionary/nginx.conf
+++ b/data_dictionary/nginx.conf
@@ -21,11 +21,11 @@ http {
     include /etc/nginx/conf.d/*.conf;
 
     server {
-        listen       8080;
+        listen       8081;
         server_name  localhost;
 
         location = / {
-            proxy_pass      http://127.0.0.1:8080;
+            proxy_pass      http://127.0.0.1:8081;
         }
     }
 }

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -43,14 +43,14 @@ data_dictionary:
 
   service:
     port:
-      http: 8080
+      http: 8081
 
   deployment:
     image:
       repository: quay.io/hmpps/pic-data-dictionary
       tag: latest
       pullPolicy: Always
-    port: 8080
+    port: 8081
 
 hearing_outcomes:
   process_un_resulted_cases_cron: "30 12-20 * * *"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,7 @@ events {
 
 
 http {
+    listen       8080;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 


### PR DESCRIPTION
- Set NGinx to listen on port 8080 as port 80 is reserved by k8s


We use an nginx that listens on port 80 `nginx/1.21.6-alpine`