### PR TITLE
PIC-3822: Catch "hex.genmodel.easy.exception.PredictUnknownCategoricalLevelException" correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ShortTermCustodyPredictorService.kt
@@ -51,7 +51,7 @@ class ShortTermCustodyPredictorService(
             model.predictBinomial(rowData)
         }
         catch (ex: PredictUnknownCategoricalLevelException) {
-            log.warn("Invalid parameter passed into algorithm", ex)
+            log.warn("Invalid parameters passed into algorithm: $rowData")
             null
         }
 


### PR DESCRIPTION
In response to an issue causing an influx of error messages in our logs, this PR addresses the uncaught exception scenario within `ShortTermCustodyPredictorService.kt`. Previously, unhandled exceptions were leading to a cluttered error log, hindering our ability to effectively monitor and troubleshoot issues.

This PR aligns with our ongoing efforts to enhance the stability and performance of our services, contributing to a more robust and reliable infrastructure.