### PR TITLE
PIC-3848 Upgrade application insights version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ dependencies {
     testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 
-    agentDeps 'com.microsoft.azure:applicationinsights-agent:3.4.9'
+    agentDeps 'com.microsoft.azure:applicationinsights-agent:3.5.2'
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10")
 
     // Spring ignores constructor binding on Kotlin data classes without this which in turn breaks hmpps-sqs-spring-boot-starter autoconfiguration


### PR DESCRIPTION
Upgrade application insights version to version `3.5.2`

hoping to fix the error:
`ERROR c.m.applicationinsights.agent - Application Insights Java Agent 3.4.9 startup failed (PID 1)`