### PR TITLE
PIC-3848 Allow SAR endpoint testing in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -83,7 +83,7 @@ env:
     base_url: https://document-api-dev.hmpps.service.justice.gov.uk
 
 spring:
-  profile: instrumented
+  profile: dev
 
 resources:
   cpu:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,6 +39,12 @@ spring:
         jwt:
           jwk-set-uri: ${nomis-oauth.base-url}/auth/.well-known/jwks.json
 
+azure:
+  application-insights:
+    web:
+      enable-W3C: true
+      enable-W3C-backcompat-mode: true
+
 hmpps:
   sar:
     additionalAccessRole: 'PREPARE_A_CASE'


### PR DESCRIPTION
Add `PREPARE_A_CASE` role to `hmpps.sar.additionalAccessRole` environment property

This allows us to test the SAR endpoint with our token that has role `PREPARE_A_CASE`