### PR TITLE
Add AWS RDS CA-Cert bundle into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt -y update && apt -y upgrade
 RUN apt install -y curl
 RUN mkdir -p /home/appuser/.postgresql
 ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /home/appuser/.postgresql/eu-west-2-bundle.pem
-RUN chown appuser:appgroup /app/certs/eu-west-2-bundle.pem
+RUN chown appuser:appgroup /home/appuser/eu-west-2-bundle.pem
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN groupadd --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
 # Install AWS RDS Root cert into Java truststore
-RUN mkdir /home/appuser/.postgresql
+RUN mkdir -p /home/appuser/.postgresql
 ADD --chown=appuser:appgroup https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /home/appuser/.postgresql/root.crt
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,9 @@ RUN groupadd --gid 2000 --system appgroup && \
 RUN mkdir -p /home/appuser
 RUN apt -y update && apt -y upgrade
 RUN apt install -y curl
-RUN mkdir -p /home/appuser/.postgresql \
-  && curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem \
-    > /home/appuser/.postgresql/root.crt
-
-
-RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem \
-    >> /home/appuser/.postgresql/root.crt
+RUN mkdir -p /home/appuser/.postgresql
+ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /home/appuser/.postgresql/eu-west-2-bundle.pem
+RUN chown appuser:appgroup /app/certs/eu-west-2-bundle.pem
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,8 @@ RUN groupadd --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
 # Install AWS RDS Root cert into Java truststore
-RUN mkdir -p /home/appuser
-RUN apt -y update && apt -y upgrade
-RUN apt install -y curl
-RUN mkdir -p /home/appuser/.postgresql
-ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /home/appuser/.postgresql/eu-west-2-bundle.pem
-RUN chown appuser:appgroup /home/appuser/eu-west-2-bundle.pem
+RUN mkdir /home/appuser/.postgresql
+ADD --chown=appuser:appgroup https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /home/appuser/.postgresql/root.crt
 
 WORKDIR /app
 


### PR DESCRIPTION
### Add AWS RDS CA-Cert bundle into Dockerfile

Allows our service to trust the [updated certificates](https://github.com/ministryofjustice/cloud-platform-environments/pull/24022) from our RDS database in cloud platform