### PR TITLE
PIC-3939 Add index on defendant names

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2179__add_defendant_name_index.sql
+++ b/src/main/resources/db/migration/courtcase/V2179__add_defendant_name_index.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS defendant_names
+    ON defendant (pnc, (name->>'forename1'), (name->>'surname'));
+
+COMMIT;


### PR DESCRIPTION
Add an index to find a defendant by PNC, forename1 and surname

We have an SQL taking up a lot of CPU and making many calls:
```
select * from defendant where pnc= $1 and date_of_birth = $2 and lower(name->>?) = lower($3) and lower(name->>?) = lower($4)
```
This index should hopefully reduce the average speed and CPU usage