### PR TITLE
PIC-4022 BugFix: Return latest draft comment from list of draft comments

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
@@ -15,5 +15,6 @@ public interface CaseCommentsRepository extends CrudRepository<CaseCommentEntity
     List<CaseCommentEntity> findByDefendantIdAndCreatedBefore(String defendantId, LocalDateTime toDate);
 
     Optional<CaseCommentEntity> findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(String caseId, String defendantId, String userUuid);
+    List<CaseCommentEntity> findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(String caseId, String defendantId, String userUuid);
     Optional<CaseCommentEntity> findByIdAndCaseIdAndDefendantIdAndCreatedByUuid(Long commentId, String caseId, String defendantId, String userUuid);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
@@ -15,6 +15,6 @@ public interface CaseCommentsRepository extends CrudRepository<CaseCommentEntity
     List<CaseCommentEntity> findByDefendantIdAndCreatedBefore(String defendantId, LocalDateTime toDate);
 
     Optional<CaseCommentEntity> findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(String caseId, String defendantId, String userUuid);
-    List<CaseCommentEntity> findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(String caseId, String defendantId, String userUuid);
+    List<CaseCommentEntity> findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(String caseId, String defendantId, String userUuid);
     Optional<CaseCommentEntity> findByIdAndCaseIdAndDefendantIdAndCreatedByUuid(Long commentId, String caseId, String defendantId, String userUuid);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/CaseCommentsRepository.java
@@ -15,6 +15,6 @@ public interface CaseCommentsRepository extends CrudRepository<CaseCommentEntity
     List<CaseCommentEntity> findByDefendantIdAndCreatedBefore(String defendantId, LocalDateTime toDate);
 
     Optional<CaseCommentEntity> findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(String caseId, String defendantId, String userUuid);
-    List<CaseCommentEntity> findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(String caseId, String defendantId, String userUuid);
+    List<CaseCommentEntity> findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(String caseId, String defendantId, String userUuid);
     Optional<CaseCommentEntity> findByIdAndCaseIdAndDefendantIdAndCreatedByUuid(Long commentId, String caseId, String defendantId, String userUuid);
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
@@ -58,7 +58,7 @@ public class CaseCommentsService {
     }
 
     public Optional<CaseCommentEntity> getDraftComment(String caseId, String defendantId, String userUuid){
-        List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(caseId, defendantId, userUuid);
+        List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(caseId, defendantId, userUuid);
         if (draftComments.size() > 1){
             // Delete older draft comments
             for (int i = 1; i < draftComments.size(); i++) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
@@ -9,11 +9,11 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.CaseCommentEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.CourtCaseEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CaseCommentsRepository;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.CourtCaseRepository;
-import uk.gov.justice.probation.courtcaseservice.jpa.repository.HearingRepository;
 import uk.gov.justice.probation.courtcaseservice.service.exceptions.EntityNotFoundException;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.justice.probation.courtcaseservice.service.TelemetryEventType.CASE_COMMENT_ADDED;
 
@@ -42,8 +42,7 @@ public class CaseCommentsService {
         Hibernate.initialize(courtCase.map(CourtCaseEntity::getCaseDefendants));
         return courtCase.filter(courtCaseEntity -> courtCaseEntity.hasDefendant(defendantId))
             .map(courtCaseEntity -> {
-                var commentToSave = caseCommentsRepository
-                    .findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(caseId, defendantId, caseComment.getCreatedByUuid())
+                var commentToSave = getDraftComment(caseId, defendantId, caseComment.getCreatedByUuid())
                     .map(caseCommentEntity -> {
                         caseCommentEntity.update(caseComment.withDraft(false));
                         return caseCommentEntity;
@@ -56,6 +55,19 @@ public class CaseCommentsService {
                 return savedCaseComment;
             })
             .orElseThrow(() -> new EntityNotFoundException("Court case %s / defendantId %s not found", caseId, defendantId));
+    }
+
+    public Optional<CaseCommentEntity> getDraftComment(String caseId, String defendantId, String userUuid){
+        List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(caseId, defendantId, userUuid);
+        if (draftComments.size() > 1){
+            // Delete older draft comments
+            for (int i = 1; i < draftComments.size(); i++) {
+                CaseCommentEntity draftComment = draftComments.get(i);
+                draftComment.setDeleted(true);
+                caseCommentsRepository.delete(draftComment);
+            }
+        }
+        return Optional.ofNullable(draftComments.getFirst());
     }
 
     public CaseCommentEntity createUpdateCaseCommentDraft(CaseCommentEntity caseComment) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
@@ -61,11 +61,10 @@ public class CaseCommentsService {
         List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(caseId, defendantId, userUuid);
         if (draftComments.size() > 1){
             // Delete older draft comments
-            for (int i = 1; i < draftComments.size(); i++) {
-                CaseCommentEntity draftComment = draftComments.get(i);
+            draftComments.stream().skip(1).forEach(draftComment -> {
                 draftComment.setDeleted(true);
                 caseCommentsRepository.delete(draftComment);
-            }
+            });
         }
         return Optional.ofNullable(draftComments.getFirst());
     }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
@@ -59,14 +59,14 @@ public class CaseCommentsService {
 
     public Optional<CaseCommentEntity> getDraftComment(String caseId, String defendantId, String userUuid){
         List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(caseId, defendantId, userUuid);
-        if (draftComments.size() > 1){
+        if (draftComments.size() > 1) {
             // Delete older draft comments
             draftComments.stream().skip(1).forEach(draftComment -> {
                 draftComment.setDeleted(true);
                 caseCommentsRepository.delete(draftComment);
             });
         }
-        return Optional.ofNullable(draftComments.getFirst());
+        return draftComments.stream().findFirst();
     }
 
     public CaseCommentEntity createUpdateCaseCommentDraft(CaseCommentEntity caseComment) {

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsService.java
@@ -58,7 +58,7 @@ public class CaseCommentsService {
     }
 
     public Optional<CaseCommentEntity> getDraftComment(String caseId, String defendantId, String userUuid){
-        List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(caseId, defendantId, userUuid);
+        List<CaseCommentEntity> draftComments = caseCommentsRepository.findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(caseId, defendantId, userUuid);
         if (draftComments.size() > 1){
             // Delete older draft comments
             for (int i = 1; i < draftComments.size(); i++) {

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
@@ -238,6 +238,7 @@ class CaseCommentsServiceTest {
         verify(courtCaseRepository).findFirstByCaseIdOrderByIdDesc(testCaseId);
         verify(caseCommentsRepository).findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid);
         verify(caseCommentsRepository).save(expectedSavedComment);
+        verify(caseCommentsRepository).delete(existingDraftCommentOldest);
     }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
@@ -225,7 +225,7 @@ class CaseCommentsServiceTest {
         var existingDraftCommentLatest = CaseCommentEntity.builder().caseId(testCaseId).defendantId(EntityHelper.DEFENDANT_ID).createdByUuid(createdByUuid).comment("comment one").id(1L).draft(true).created(LocalDateTime.now()).build();
         var existingDraftCommentOldest = CaseCommentEntity.builder().caseId(testCaseId).defendantId(EntityHelper.DEFENDANT_ID).createdByUuid(createdByUuid).comment("comment one").id(2L).draft(true).created(LocalDateTime.now().minusHours(1)).build();
 
-        given(caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid))
+        given(caseCommentsRepository.findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid))
                 .willReturn(List.of(existingDraftCommentLatest, existingDraftCommentOldest));
 
         var expectedSavedComment = existingDraftCommentLatest.withComment("updated comment").withDraft(false);
@@ -236,7 +236,7 @@ class CaseCommentsServiceTest {
         caseCommentsService.createCaseComment(expectedSavedComment);
 
         verify(courtCaseRepository).findFirstByCaseIdOrderByIdDesc(testCaseId);
-        verify(caseCommentsRepository).findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid);
+        verify(caseCommentsRepository).findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid);
         verify(caseCommentsRepository).save(expectedSavedComment);
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
@@ -65,13 +65,13 @@ class CaseCommentsServiceTest {
         var courtCase = EntityHelper.aHearingEntity().getCourtCase();
         given(courtCaseRepository.findFirstByCaseIdOrderByIdDesc(EntityHelper.CASE_ID)).willReturn(Optional.of(courtCase));
 
-        given(caseCommentsRepository.findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(EntityHelper.CASE_ID, EntityHelper.DEFENDANT_ID, createdByUuid))
-            .willReturn(Optional.of(existingComment));
+        given(caseCommentsRepository.findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(EntityHelper.CASE_ID, EntityHelper.DEFENDANT_ID, createdByUuid))
+            .willReturn(List.of(existingComment));
 
         var expectedComment = existingComment.withComment("updated and finalised comment to save").withDraft(false);
         given(caseCommentsRepository.save(expectedComment)).willReturn(caseComment);
         caseCommentsService.createCaseComment(expectedComment);
-        verify(caseCommentsRepository).findByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrue(EntityHelper.CASE_ID, EntityHelper.DEFENDANT_ID, createdByUuid);
+        verify(caseCommentsRepository).findAllByCaseIdAndDefendantIdAndCreatedByUuidAndDraftIsTrueOrderByCreatedDesc(EntityHelper.CASE_ID, EntityHelper.DEFENDANT_ID, createdByUuid);
         verify(caseCommentsRepository).save(existingComment.withDraft(false).withComment("updated and finalised comment to save"));
         verify(telemetryService).trackCourtCaseCommentEvent(CASE_COMMENT_ADDED, caseComment);
     }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/CaseCommentsServiceTest.java
@@ -225,7 +225,7 @@ class CaseCommentsServiceTest {
         var existingDraftCommentLatest = CaseCommentEntity.builder().caseId(testCaseId).defendantId(EntityHelper.DEFENDANT_ID).createdByUuid(createdByUuid).comment("comment one").id(1L).draft(true).created(LocalDateTime.now()).build();
         var existingDraftCommentOldest = CaseCommentEntity.builder().caseId(testCaseId).defendantId(EntityHelper.DEFENDANT_ID).createdByUuid(createdByUuid).comment("comment one").id(2L).draft(true).created(LocalDateTime.now().minusHours(1)).build();
 
-        given(caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid))
+        given(caseCommentsRepository.findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid))
                 .willReturn(List.of(existingDraftCommentLatest, existingDraftCommentOldest));
 
         var expectedSavedComment = existingDraftCommentLatest.withComment("updated comment").withDraft(false);
@@ -236,7 +236,7 @@ class CaseCommentsServiceTest {
         caseCommentsService.createCaseComment(expectedSavedComment);
 
         verify(courtCaseRepository).findFirstByCaseIdOrderByIdDesc(testCaseId);
-        verify(caseCommentsRepository).findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedAtDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid);
+        verify(caseCommentsRepository).findAllByIdAndCaseIdAndDefendantIdAndCreatedByUuidOrderByCreatedDescAndDraftIsTrue(testCaseId, EntityHelper.DEFENDANT_ID, createdByUuid);
         verify(caseCommentsRepository).save(expectedSavedComment);
     }
 


### PR DESCRIPTION
Due to a data race, more than 1 draft comments can be saved in the database which shouldn't happen.

This leads to users unable to save a comment, which is caused by the below `NonUniqueResultException` exception

Most commonly, more than 1 draft comment exists that were created milliseconds apart.
`jakarta.persistence.NonUniqueResultException: query did not return a unique result: 2`


This fix returns and updates only the latest draft comment and deletes the older draft comments.

Also, add a unit test