### PR TITLE
PIC-4138 Fix null pointer exception when trying to get offenders' defendants

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
@@ -122,8 +122,13 @@ public class HearingRepositoryFacade {
     }
 
     private void updateWithExistingOffenders(HearingEntity hearingEntity) {
-        hearingEntity.getHearingDefendants().stream().filter(hearingDefendantEntity -> Objects.nonNull(hearingDefendantEntity.getDefendant().getOffender()) &&
-                                    Objects.isNull(hearingDefendantEntity.getDefendant().getOffender().getId()))
+        hearingEntity.getHearingDefendants().stream().filter(hearingDefendantEntity -> {
+                    if (hearingDefendantEntity.getDefendant().getOffender() == null) {
+                        log.info("Defendant with id {} has no offender", hearingDefendantEntity.getDefendant().getDefendantId());
+                    }
+                    return Objects.nonNull(hearingDefendantEntity.getDefendant().getOffender()) &&
+                                    Objects.isNull(hearingDefendantEntity.getDefendant().getOffender().getId());
+                        })
             .forEach((HearingDefendantEntity hearingDefendantEntity) -> {
                 var defendant = hearingDefendantEntity.getDefendant();
                 var updatedOffender = offenderRepositoryFacade.upsertOffender(defendant.getOffender());

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
@@ -122,13 +122,8 @@ public class HearingRepositoryFacade {
     }
 
     private void updateWithExistingOffenders(HearingEntity hearingEntity) {
-        hearingEntity.getHearingDefendants().stream().filter(hearingDefendantEntity -> {
-                    if (hearingDefendantEntity.getDefendant().getOffender() == null) {
-                        log.info("Defendant with id {} has no offender", hearingDefendantEntity.getDefendant().getDefendantId());
-                    }
-                    return Objects.nonNull(hearingDefendantEntity.getDefendant().getOffender()) &&
-                                    Objects.isNull(hearingDefendantEntity.getDefendant().getOffender().getId());
-                        })
+        hearingEntity.getHearingDefendants().stream().filter(hearingDefendantEntity -> Objects.nonNull(hearingDefendantEntity.getDefendant().getOffender()) &&
+                                    Objects.isNull(hearingDefendantEntity.getDefendant().getOffender().getId()))
             .forEach((HearingDefendantEntity hearingDefendantEntity) -> {
                 var defendant = hearingDefendantEntity.getDefendant();
                 var updatedOffender = offenderRepositoryFacade.upsertOffender(defendant.getOffender());

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
@@ -27,8 +27,6 @@ public class OffenderEntityInitService {
             Hibernate.initialize(offender.get().getDefendants());
             if (o.getDefendants() != null) {
                 o.getDefendants().forEach(defendantEntity -> Hibernate.initialize(defendantEntity.getHearingDefendants()));
-            } else {
-                log.error("Offender with crn {} has no defendants", crn);
             }
         });
         return offender;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
@@ -25,7 +25,7 @@ public class OffenderEntityInitService {
         // Hibernate initialize seems to have issues if mapping over an optional
         offender.ifPresent(o -> {
             Hibernate.initialize(offender.get().getDefendants());
-            if (o.getDefendants() != null) {
+            if (o.getDefendants() != null) { // getDefendants() requires the defendant to exist in the database with an association to this offender.
                 o.getDefendants().forEach(defendantEntity -> Hibernate.initialize(defendantEntity.getHearingDefendants()));
             }
         });

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
@@ -20,10 +20,13 @@ public class OffenderEntityInitService {
     @Transactional
     public Optional<OffenderEntity> findByCrn(String crn) {
         var offender = offenderRepository.findByCrn(crn);
-        if(offender.isPresent()) { //Hibernate initialize seems to have issues if mapping over an optional
+        // Hibernate initialize seems to have issues if mapping over an optional
+        offender.ifPresent(o -> {
             Hibernate.initialize(offender.get().getDefendants());
-            offender.get().getDefendants().forEach(defendantEntity -> Hibernate.initialize(defendantEntity.getHearingDefendants()));
-        }
+            if (o.getDefendants() != null) {
+                o.getDefendants().forEach(defendantEntity -> Hibernate.initialize(defendantEntity.getHearingDefendants()));
+            }
+        });
         return offender;
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,7 @@ import uk.gov.justice.probation.courtcaseservice.jpa.repository.OffenderReposito
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 public class OffenderEntityInitService {
 
@@ -25,6 +27,8 @@ public class OffenderEntityInitService {
             Hibernate.initialize(offender.get().getDefendants());
             if (o.getDefendants() != null) {
                 o.getDefendants().forEach(defendantEntity -> Hibernate.initialize(defendantEntity.getHearingDefendants()));
+            } else {
+                log.error("Offender with crn {} has no defendants", crn);
             }
         });
         return offender;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitServiceTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.DefendantEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.Sex;
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.OffenderRepository;
 
 import java.util.Optional;
@@ -38,7 +40,7 @@ public class OffenderEntityInitServiceTest {
 
         given(offenderRepository.findByCrn(CRN)).willReturn(Optional.of(existingOffender));
 
-        assertThat(offenderEntityInitService.findByCrn(CRN)).isEqualTo(existingOffender);
+        assertThat(offenderEntityInitService.findByCrn(CRN)).isEqualTo(Optional.of(existingOffender));
     }
 
     @Test
@@ -46,5 +48,32 @@ public class OffenderEntityInitServiceTest {
         var CRN = "XYZXYZ";
 
         assertThat(offenderEntityInitService.findByCrn(CRN)).isEmpty();
+    }
+
+    @Test
+    void givenOffenderExistsAndNoDefendantExists_existingOffenderReturns() {
+        var CRN = "CRN001";
+
+        final var defendant = DefendantEntity.builder()
+                .defendantId("51354F3C-9625-404D-B820-C74724D23484")
+                .personId("96624bb7-c64d-46d9-a427-813ec168f95a")
+                .crn("CRN001")
+                .sex(Sex.MALE)
+                .offenderConfirmed(true).build();
+
+        final var existingOffender = OffenderEntity.builder()
+                .crn(CRN)
+                .breach(false)
+                .awaitingPsr(true)
+                .probationStatus(CURRENT)
+                .suspendedSentenceOrder(true)
+                .preSentenceActivity(false)
+                .build();
+
+        defendant.setOffender(existingOffender);
+
+        given(offenderRepository.findByCrn(CRN)).willReturn(Optional.of(existingOffender));
+
+        assertThat(offenderEntityInitService.findByCrn(CRN)).isEqualTo(Optional.of(existingOffender));
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/OffenderEntityInitServiceTest.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.probation.courtcaseservice.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderEntity;
+import uk.gov.justice.probation.courtcaseservice.jpa.repository.OffenderRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderProbationStatus.CURRENT;
+
+@ExtendWith(MockitoExtension.class)
+public class OffenderEntityInitServiceTest {
+
+    @Mock
+    private OffenderRepository offenderRepository;
+
+    @InjectMocks
+    private OffenderEntityInitService offenderEntityInitService;
+
+    @Test
+    void givenOffenderExist_existingOffenderReturns() {
+        var CRN = "CRN001";
+
+        final var existingOffender = OffenderEntity.builder()
+                .crn(CRN)
+                .breach(false)
+                .awaitingPsr(true)
+                .probationStatus(CURRENT)
+                .suspendedSentenceOrder(true)
+                .preSentenceActivity(false)
+                .build();
+
+        given(offenderRepository.findByCrn(CRN)).willReturn(Optional.of(existingOffender));
+
+        assertThat(offenderEntityInitService.findByCrn(CRN)).isEqualTo(existingOffender);
+    }
+
+    @Test
+    void givenOffenderDoesNotExist_NothingIsReturned() {
+        var CRN = "XYZXYZ";
+
+        assertThat(offenderEntityInitService.findByCrn(CRN)).isEmpty();
+    }
+}


### PR DESCRIPTION
1. Prevent null pointer exceptions by checking to see if the offender.defendants is null or not. This is because we use an optional offender.get() in order to hibernate.initialize / lazy load defendant data.
2. Add unit tests


Atm, we often see null pointer exceptions in the logs.

I believe that once the defendant / hearing is saved then the offender / defendant association will be fixed and you'll then be able to do offender.getDefendants() because a defendant actually then exists

⚠️ We have a seperate investigation to understand why offender.getDefendants is returning null instead of an empty list

My assumption is that we can have an Offender in the database coming from e.g. the pic_new_offender_events_queue .
That could lead to the defendant not existing in the table until the case / hearing is sent through to use from HMCTS.

I think it's worth further investigating **why an offender can exist in our database but no related Defendant in the database**