### PR TITLE
PIC-4138 Remove logs after resolving bug

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacade.java
@@ -123,17 +123,12 @@ public class HearingRepositoryFacade {
 
     private void updateWithExistingOffenders(HearingEntity hearingEntity) {
         hearingEntity.getHearingDefendants().stream().filter(hearingDefendantEntity -> {
-                    if (hearingDefendantEntity.getDefendant().getOffender() == null) {
-                        log.info("Defendant with id {} has no offender", hearingDefendantEntity.getDefendant().getDefendantId());
-                    }
                     return Objects.nonNull(hearingDefendantEntity.getDefendant().getOffender()) &&
                                     Objects.isNull(hearingDefendantEntity.getDefendant().getOffender().getId());
                         })
             .forEach((HearingDefendantEntity hearingDefendantEntity) -> {
                 var defendant = hearingDefendantEntity.getDefendant();
                 var updatedOffender = offenderRepositoryFacade.upsertOffender(defendant.getOffender());
-
-                log.info("Updated offender has defendants? {}", !(Objects.isNull(updatedOffender.getDefendants()) || updatedOffender.getDefendants().isEmpty()));
                 defendant.setOffender(updatedOffender);
         });
     }


### PR DESCRIPTION
Remove logs that were used solely to debug a null pointer exception. It has been resolved so there's no longer a need for the logs.