### PR TITLE
PIC-4205 Update domain name to non-cluster specific

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: court-case-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: court-case-service-dev.apps.cloud-platform.service.justice.gov.uk
   path: /
 
 nginx_proxy:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,7 +17,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: court-case-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: court-case-service-preprod.apps.cloud-platform.service.justice.gov.uk
   path: /
 
 nginx_proxy:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,7 +17,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: court-case-service.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: court-case-service.apps.cloud-platform.service.justice.gov.uk
       cert_secret: court-case-service-cert
   path: /
 


### PR DESCRIPTION
Migrate to non-cluster specific domain names

This is due to Cloud Platform's recommendations: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrating-from-live-1-domain-name.html#resources-deployed-using-kubectl

CP has a list of services still specifying live-1 https://reports.cloud-platform.service.justice.gov.uk/live_1_domains
. Our service is on there.

> IMPORTANT: Switching your domain over will incur a short delay due to DNS propagation. We strongly advise you to test in non-production environments before making the change on any production environments.

This PR doesn't go through a staged migration so i think it'd be best to do an out of hours release. Unless, we think it's better to do a staged solution?