### PR TITLE
Alter sequence for court_case table

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2182__rename_court_case_sequences.sql
+++ b/src/main/resources/db/migration/courtcase/V2182__rename_court_case_sequences.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER SEQUENCE IF EXISTS court_case_id_seq RENAME TO court_case_old_id_seq;
+ALTER SEQUENCE IF EXISTS court_case_new_id_seq RENAME TO court_case_id_seq;
+
+COMMIT;


### PR DESCRIPTION
Set the new_sequence to court_case_id_seq so that Hibernate can use it to set the id value during table insertions

Set the old_sequence from court_case_id_seq to court_case_old_id_seq which is no longer being used. (TODO: remove)

This should fix DataIntegrityViolationException issues we get which causes a lot of noise in our error logs

Error it resolves:
```
DataIntegrityViolationException
could not execute statement [ERROR: duplicate key value violates unique constraint "court_case_new_pkey"
  Detail: Key (id)=(redacted) already exists.]
```


**Azure error:**

[Logs here](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%225055501c-7b54-11ef-ac1d-000d3a86bbe1%22,%22timestamp%22:%222024-09-25T15:38:55.362Z%22%7D/ComponentId/%7B%22Name%22:%22nomisapi-prod%22,%22ResourceGroup%22:%22nomisapi-prod-rg%22,%22SubscriptionId%22:%22a5ddf257-3b21-4ba9-a28c-ab30f751b383%22%7D)

**New sequence was not being used by Hibernate:**
<img width="516" alt="image" src="https://github.com/user-attachments/assets/b399bfff-5d08-4fbb-9ab4-12b1bf370652">
