### PR TITLE
Set the default sequence on the court_case table

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2183__add_sequence_to_court_case.sql
+++ b/src/main/resources/db/migration/courtcase/V2183__add_sequence_to_court_case.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS COURT_CASE ALTER COLUMN id SET DEFAULT nextval('court_case_id_seq');
+
+COMMIT;


### PR DESCRIPTION
Set the default sequence on the court_case table

The court_case table has no default sequence on the id column in all environments. This change should set it to the expected `court_case_id_seq` sequence