### PR TITLE
Add read only database user for developers

### DIFF
--- a/helm_deploy/court-case-service/templates/_envs.tpl
+++ b/helm_deploy/court-case-service/templates/_envs.tpl
@@ -193,6 +193,18 @@ env:
         name: sqs-pic-new-offender-events-dlq-secret
         key: sqs_queue_name
 
+  - name: DATABASE_READONLY_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: court-case-service-readonly-user
+        key: database_readonly_username
+
+  - name: DATABASE_READONLY_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: court-case-service-readonly-user
+        key: database_readonly_password
+
   {{- with (index .Values.ingress.hosts 0)}}
   - name: INGRESS_URL
     value: {{ .host }}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -77,6 +77,11 @@ spring:
   flyway:
     defaultSchema: courtcaseservice
     locations: classpath:db/migration/courtcase, filesystem:src/test/resources/db/migration/local, filesystem:src/test/resources
+    placeholders:
+      schemas: ${database.schema.name}
+      readonly:
+        user: readonly
+        password: password
   jpa:
     show-sql: true
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,6 +94,11 @@ spring:
     schemas: ${database.schema.name}
     locations: classpath:db/migration/courtcase
     enabled: true
+    placeholders:
+      schemas: ${database.schema.name}
+      readonly:
+        user: ${database.readonly.username}
+        password: ${database.readonly.password}
 
 
   jpa:

--- a/src/main/resources/db/migration/courtcase/V2183__add_readonly_user.sql
+++ b/src/main/resources/db/migration/courtcase/V2183__add_readonly_user.sql
@@ -1,0 +1,13 @@
+-- Create a group
+CREATE ROLE readonly;
+
+-- Grant access to existing tables
+GRANT USAGE ON SCHEMA ${schemas} TO readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA ${schemas} TO readonly;
+
+-- Grant access to future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA ${schemas} GRANT SELECT ON TABLES TO readonly;
+
+-- Create a final user with password
+CREATE USER ${readonly.user} WITH PASSWORD '${readonly.password}';
+GRANT readonly TO ${readonly.user};

--- a/src/main/resources/db/migration/courtcase/V2183__add_readonly_user.sql
+++ b/src/main/resources/db/migration/courtcase/V2183__add_readonly_user.sql
@@ -1,4 +1,6 @@
 -- Create a group
+DROP ROLE IF EXISTS readonly;
+
 CREATE ROLE readonly;
 
 -- Grant access to existing tables

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -43,6 +43,11 @@ hmpps-document-management-api-client:
 spring:
   flyway:
     clean-on-validation-error: true
+    placeholders:
+      schemas: courtcaseservicetest
+      readonly:
+        user: readonly
+        password: password
   jpa:
     show-sql: false
     properties:


### PR DESCRIPTION
Add a read only database user for developers to use when accessing the database


This is so that developers can connect to the database with read only permissions and it prevents any accidental writes