### PR TITLE
Use latest court-case from duplicated data

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepository.java
@@ -17,7 +17,8 @@ public interface HearingRepository extends CrudRepository<HearingEntity, Long>, 
     Optional<HearingEntity> findFirstByHearingId(String hearingId);
 
     @Query(value = "select * from hearing h where h.hearing_id = :hearingId " +
-            "and fk_court_case_id = (select id from court_case where case_id = :caseId)",
+            "and fk_court_case_id = (select id from court_case where case_id = :caseId and deleted = false order by created desc limit 1) " +
+            "and deleted = false",
             nativeQuery = true)
     Optional<HearingEntity> findByHearingIdAndCaseId(String hearingId, String caseId);
 

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacadeIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingRepositoryFacadeIntTest.java
@@ -89,6 +89,13 @@ public class HearingRepositoryFacadeIntTest extends BaseIntTest {
     }
 
     @Test
+    public void whenFindFirstByHearingIdAndCourtCaseIdAndDuplicateData_thenReturnCorrectRecordWithOffender() {
+        final var actual = hearingRepositoryFacade.findFirstByHearingIdAndCourtCaseId("5564cbfd-3d53-4f36-9508-437416b08738", "727af2a3-f9ec-4544-b5ef-2ec3ec0fcf2b");
+
+        assertIsFerrisBueller(actual);
+    }
+
+    @Test
     public void whenFindByHearingIdAndDefendantId_thenReturnCorrectRecordWithOffender() {
         final var actual = hearingRepositoryFacade.findByHearingIdAndDefendantId("5564cbfd-3d53-4f36-9508-437416b08738", "0048297a-fd9c-4c96-8c03-8122b802a54d");
 

--- a/src/test/resources/sql/before-HearingRepositoryFacadeIntTest.sql
+++ b/src/test/resources/sql/before-HearingRepositoryFacadeIntTest.sql
@@ -19,6 +19,20 @@ VALUES (-198, '0048297a-fd9c-4c96-8c03-8122b802a54d', '732cce04-4b9e-11ed-bdc3-0
 INSERT INTO HEARING_DEFENDANT (id, fk_hearing_id, created, defendant_id, FK_DEFENDANT_ID)
 VALUES (-198, -198, '2022-03-23 16:59:59.000', '0048297a-fd9c-4c96-8c03-8122b802a54d', -198);
 
+-- Insert duplicate data
+-- hearing and court_case created date is 1 second before original
+INSERT INTO case_comments(id, case_id, defendant_id, comment, "author", created, deleted, created_by, created_by_uuid) VALUES (-1700028902, '727af2a3-f9ec-4544-b5ef-2ec3ec0fcf2b', '1148297a-fd9c-4c96-8c03-8122b802a54d', 'PSR completed', 'Author One', now(), true, 'before-test.sql', 'fb9a3bbf-360b-48d1-bdd6-b9292f9a0d81');
+INSERT INTO court_case (id, case_id, case_no, created, source_type)
+VALUES (-199, '727af2a3-f9ec-4544-b5ef-2ec3ec0fcf2b', '1600028888', '2022-03-23 17:59:58.000', 'COMMON_PLATFORM');
+INSERT INTO hearing (id, fk_court_case_id, hearing_id, created, list_no)
+VALUES (-199, -199, '5564cbfd-3d53-4f36-9508-437416b08738', '2022-03-23 17:59:58.000', '3rd');
+INSERT INTO HEARING_DAY (id, fk_hearing_id, court_code, court_room, hearing_day, hearing_time, created)
+VALUES (-199, -199, 'B33HU', 1, '2022-3-25', '09:00', '2022-03-23 17:59:59.000');
+INSERT INTO DEFENDANT (id, DEFENDANT_ID, PERSON_ID, defendant_name, name, address, type, date_of_birth, crn, sex, created, FK_OFFENDER_ID)
+VALUES (-199, '0148297a-fd9c-4c96-8c03-8122b802a54d', '732cce04-4b9e-11ed-bdc3-0242ac120002', 'Mr Ferris BUELLER', '{"title": "Mr", "surname": "BUELLER", "forename1": "Ferris", "forename2": "Antimony"}', '{"line1": "27", "line2": "Elm Place", "postcode": "ad21 5dr", "line3": "Bangor", "line4": null, "line5": null}', 'PERSON', '1958-10-10', 'X25829', 'MALE', '2022-03-23 17:59:59.000', -100);
+INSERT INTO HEARING_DEFENDANT (id, fk_hearing_id, created, defendant_id, FK_DEFENDANT_ID)
+VALUES (-199, -199, '2022-03-23 16:59:59.000', '0148297a-fd9c-4c96-8c03-8122b802a54d', -199);
+
 -- For null listNo int test
 INSERT INTO OFFENCE (ID, FK_HEARING_DEFENDANT_ID, TITLE, SUMMARY, ACT, SEQUENCE, CREATED)
 VALUES (-198, -198, 'Theft from a garage', 'On 01/01/2015 at own, stole article, to the value of £987.00, belonging to person.', 'Contrary to section 1(1) and 7 of the Theft Act 1968.', 1, '2022-03-23 17:59:59.000');


### PR DESCRIPTION
Update the find hearing by to use the latest created_date to get the court_case with the same case_id

We get duplicated data due to a race condition in court_case table

This will prevent postgres failures due to more than one row being returned