### PR TITLE
Add index to hearing defendant table

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2185__add_index_hearing_defendant_table.sql
+++ b/src/main/resources/db/migration/courtcase/V2185__add_index_hearing_defendant_table.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS hearing_defendant_fk_defendant_id_idx ON hearing_defendant (fk_defendant_id);
+
+COMMIT;


### PR DESCRIPTION
Add index to hearing defendant table on `fk_defendant_id`

One of the slowest and most CPU intensive queries is the one hibernate does to get all the hearing_defendants based on the defendant id. As in, the Defendant entity has many hearing defendants.

There's a similar query to get all hearing defendants using the fk_hearing_id which takes 8ms whilst the same one with fk_defendant_id takes 400ms. Hopefully the index should improve this

Adding an index to this should hopefully reduce the time it takes to retrieve this information and should improve performance on the PUT /hearing requests
