### PR TITLE
PIC-4372 Add constraint on hearing table for hearing_id and court_case_id

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedHearingRequestResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedHearingRequestResponse.java
@@ -253,6 +253,7 @@ public class ExtendedHearingRequestResponse {
                         .caseMarkers(caseMarkerEntities)
                         .build())
                 .hearingId(Optional.ofNullable(hearingId).orElse(caseId))
+                .courtCaseId(caseId)
                 .hearingEventType(HearingEventType.fromString(hearingEventType))
                 .hearingType(hearingType)
                 .listNo(

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/HearingEntity.java
@@ -56,10 +56,14 @@ public class HearingEntity extends BaseAuditedEntity implements Serializable {
     @Column(name = "HEARING_ID", nullable = false)
     private String hearingId;
 
+    @Column(name = "COURT_CASE_ID")
+    private String courtCaseId;
+
     @ManyToOne(optional = false, cascade = CascadeType.ALL)
     @JoinColumn(name = "FK_COURT_CASE_ID", referencedColumnName = "id", nullable = false)
     @Setter
     private CourtCaseEntity courtCase;
+
 
     // If you have more than one collection with fetch = FetchType.EAGER then there is an exception
     // org.hibernate.loader.MultipleBagFetchException: cannot simultaneously fetch multiple bags

--- a/src/main/resources/db/migration/courtcase/V2186__add_case_id_to_hearing.sql
+++ b/src/main/resources/db/migration/courtcase/V2186__add_case_id_to_hearing.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE if exists hearing ADD COLUMN court_case_id TEXT;
+
+END;

--- a/src/main/resources/db/migration/courtcase/V2187__add_constraint_to_hearing.sql
+++ b/src/main/resources/db/migration/courtcase/V2187__add_constraint_to_hearing.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS hearing ADD CONSTRAINT hearing_court_case_id_uniq UNIQUE (hearing_id, court_case_id);
+
+COMMIT;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedHearingRequestResponseTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/model/ExtendedHearingRequestResponseTest.java
@@ -75,6 +75,7 @@ class ExtendedHearingRequestResponseTest {
         final var hearingEntity = request.asHearingEntity();
 
         assertThat(hearingEntity.getCaseId()).isEqualTo("CASE_ID");
+        assertThat(hearingEntity.getCourtCaseId()).isEqualTo("CASE_ID");
         assertThat(hearingEntity.getHearingId()).isEqualTo("HEARING_ID");
         assertThat(hearingEntity.getListNo()).isEqualTo(LIST_NO);
         assertThat(hearingEntity.getCourtCase().getUrn()).isEqualTo(URN);

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/EntityHelper.java
@@ -140,6 +140,7 @@ public class EntityHelper {
                         .urn(URN)
                         .sourceType(SOURCE)
                         .build())
+                .courtCaseId(CASE_ID)
                 .hearingDefendants(defendants)
                 .build();
     }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceIntTest.java
@@ -65,6 +65,7 @@ public class ImmutableCourtCaseServiceIntTest extends BaseIntTest {
 
         HearingEntity savedHearing = courtCaseService.createOrUpdateHearingByHearingId(newHearingEntity.getHearingId(), newHearingEntity).block();
         assertThat(savedHearing.withId(null)).isEqualTo(newHearingEntity.withId(null));
+        assertThat(savedHearing.getCourtCaseId()).isEqualTo(newHearingEntity.getCourtCaseId());
 
         assertThatHearingIsNotImmutable(caseId, hearingId, DEFENDANT_ID_1);
         var hearingAudits = findAllAuditByHearingId(hearingId);

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/service/ImmutableCourtCaseServiceTest.java
@@ -315,6 +315,7 @@ class ImmutableCourtCaseServiceTest {
             verify(hearingRepositoryFacade).save(hearing);
             assertThat(savedCourtCase).isNotNull();
             assertThat(savedCourtCase.getHearingId()).isEqualTo(HEARING_ID);
+            assertThat(savedCourtCase.getCourtCaseId()).isEqualTo(CASE_ID);
             verifyNoMoreInteractions(hearingRepositoryFacade, telemetryService);
         }
 


### PR DESCRIPTION
Add constraint on hearing table for hearing_id and court_case_id

This will be used in a later commit to add a constraint on the hearing table on hearing id and courtCaseId so that we can prevent any more duplicates due to data race issues in our service


Add column court_case_id which is a uuid of the case_id
Update tests