### PR TITLE
PIC-4372b Fix audit table issue in preprod

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantEntity.java
@@ -13,8 +13,6 @@ import lombok.With;
 import lombok.experimental.SuperBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import org.hibernate.type.SqlTypes;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,8 @@ spring:
       org:
         hibernate:
           flushMode: COMMIT
+          envers:
+            store_data_at_delete: true
     open-in-view: false
   servlet:
     multipart:


### PR DESCRIPTION
Set store_data_at_delete to true.

**This fixes the issue below:**
`
org.postgresql.util.PSQLException: ERROR: null value in column "prep_status" of relation "hearing_defendant_aud" violates not-null constraint
`

When a record is deleted in the original table, the audit table does an insert with null values in the columns. However, there's a not null constraint on the prep_status column which causes an exception. This configuration should stop the need to add null values for a deltion.

- Also, remove unused imports
