### PR TITLE
PIC-4372b Remove-audit-table-constraint

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2190__remove_constaint_hearing_defendant_aud.sql
+++ b/src/main/resources/db/migration/courtcase/V2190__remove_constaint_hearing_defendant_aud.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE if exists hearing_outcome_aud DROP CONSTRAINT fk_hearing_defendant_hearing_outcome;
+END;


### PR DESCRIPTION
Remove `fk_hearing_defendant_hearing_outcome` constraint from the audit table.

This will allow for duplicate hearing_defendants to be removed and duplicate hearing outcomes.