### PR TITLE
PIC-4509 Fix case document lazy loading

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.probation.courtcaseservice.controller.mapper;
 
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CaseCommentResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CaseDocumentResponse;
@@ -47,7 +48,10 @@ public class CourtCaseResponseMapper {
 
     private static List<CaseDocumentResponse> mapCaseDocuments(HearingEntity hearingEntity, String defendantId) {
         return hearingEntity.getCourtCase().getCaseDefendant(defendantId)
-            .map(CaseDefendantEntity::getDocuments)
+            .map(caseDefendantEntity -> {
+                Hibernate.initialize(caseDefendantEntity.getDocuments());
+                return caseDefendantEntity.getDocuments();
+            })
             .map(caseDefendantDocumentEntities -> caseDefendantDocumentEntities.stream()
                 .map(doc -> new CaseDocumentResponse(doc.getDocumentId(),doc.getCreated(), new CaseDocumentResponse.FileResponse(doc.getDocumentName(), 0)))
                 .collect(Collectors.toList())


### PR DESCRIPTION
Lazy load the case defendants documents to fix the error:

> org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: uk.gov.justice.probation.courtcaseservice.jpa.entity.CaseDefendantEntity.documents: could not initialize proxy - no Session

...

> uk.gov.justice.probation.courtcaseservice.controller.mapper.CourtCaseResponseMapper.mapCaseDocuments(CourtCaseResponseMapper.java:51)