### PR TITLE
BugFix: Lazy load case documents

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseController.java
@@ -82,6 +82,7 @@ public class CourtCaseController {
     private final AuthenticationHelper authenticationHelper;
     private final CaseProgressService caseProgressService;
     private final HearingNotesService hearingNotesService;
+    private final CourtCaseResponseMapper courtCaseResponseMapper;
 
     @Autowired
     public CourtCaseController(CourtCaseService courtCaseService,
@@ -91,6 +92,7 @@ public class CourtCaseController {
                                AuthenticationHelper authenticationHelper,
                                CaseProgressService caseProgressService,
                                HearingNotesService hearingNotesService,
+                               CourtCaseResponseMapper courtCaseResponseMapper,
                                @Value("${feature.flags.enable-cacheable-case-list:true}") boolean enableCacheableCaseList) {
         this.courtCaseService = courtCaseService;
         this.offenderMatchService = offenderMatchService;
@@ -100,6 +102,7 @@ public class CourtCaseController {
         this.authenticationHelper = authenticationHelper;
         this.caseProgressService = caseProgressService;
         this.hearingNotesService = hearingNotesService;
+        this.courtCaseResponseMapper = courtCaseResponseMapper;
     }
 
     @Operation(description = "Gets the court case data by hearing id and defendant id.")
@@ -386,7 +389,7 @@ public class CourtCaseController {
     private CourtCaseResponse buildCourtCaseResponseForCaseIdAndDefendantId(HearingEntity hearingEntity, String defendantId, List<CaseProgressHearing> caseHearings) {
         final var offenderMatchesCount = offenderMatchService.getMatchCountByCaseIdAndDefendant(hearingEntity.getCaseId(), defendantId)
                 .orElse(0);
-        return CourtCaseResponseMapper.mapFrom(hearingEntity, defendantId, offenderMatchesCount, caseHearings);
+        return courtCaseResponseMapper.mapFrom(hearingEntity, defendantId, offenderMatchesCount, caseHearings);
     }
 
     private CourtCaseResponse buildCourtCaseResponse(HearingEntity hearingEntity) {
@@ -412,6 +415,6 @@ public class CourtCaseController {
     private CourtCaseResponse buildCourtCaseResponse(HearingEntity hearingEntity, LocalDate hearingDate, HearingDefendantEntity hearingDefendantEntity) {
         final var defendant = Optional.ofNullable(hearingDefendantEntity).map(HearingDefendantEntity::getDefendant).orElseThrow();
         var matchCount = offenderMatchService.getMatchCountByCaseIdAndDefendant(hearingEntity.getCaseId(), defendant.getDefendantId()).orElse(0);
-        return CourtCaseResponseMapper.mapFrom(hearingEntity, hearingDefendantEntity, matchCount, hearingDate);
+        return courtCaseResponseMapper.mapFrom(hearingEntity, hearingDefendantEntity, matchCount, hearingDate);
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.probation.courtcaseservice.controller.mapper;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Hibernate;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/HearingEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/HearingEntityInitService.java
@@ -71,9 +71,10 @@ public class HearingEntityInitService {
     }
 
     @Transactional
-    public void initializeCaseDocuments(HearingEntity hearing) {
+    public HearingEntity initializeCaseDocuments(HearingEntity hearing) {
         Hibernate.initialize(hearing.getCourtCase().getCaseDefendants());
         hearing.getCourtCase().getCaseDefendants().forEach(caseDefendantEntity -> Hibernate.initialize(caseDefendantEntity.getDocuments()));
+        return hearing;
     }
 
     @Transactional

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/service/HearingEntityInitService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/service/HearingEntityInitService.java
@@ -71,6 +71,12 @@ public class HearingEntityInitService {
     }
 
     @Transactional
+    public void initializeCaseDocuments(HearingEntity hearing) {
+        Hibernate.initialize(hearing.getCourtCase().getCaseDefendants());
+        hearing.getCourtCase().getCaseDefendants().forEach(caseDefendantEntity -> Hibernate.initialize(caseDefendantEntity.getDocuments()));
+    }
+
+    @Transactional
     public Optional<HearingEntity> findByHearingIdAndInitHearingNotes(String hearingId, String defendantId) {
         var hearing = hearingRepository.findByHearingIdAndHearingDefendantsDefendantIdAndDeletedFalse(hearingId, defendantId);
         if(hearing.isPresent()) {

--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ProbationCaseEngagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/service/ProbationCaseEngagementService.kt
@@ -4,7 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.probation.courtcaseservice.client.model.DeliusOffenderDetail
-import uk.gov.justice.probation.courtcaseservice.client.model.ProbationStatus
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderEntity
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.OffenderProbationStatus
 import uk.gov.justice.probation.courtcaseservice.jpa.repository.DefendantRepository

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
@@ -3,10 +3,10 @@ package uk.gov.justice.probation.courtcaseservice.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.kotlin.MockingKt;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.WebRequest;
 import reactor.core.publisher.Mono;
@@ -20,13 +20,7 @@ import uk.gov.justice.probation.courtcaseservice.controller.model.HearingNoteReq
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingSearchRequest;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.*;
 import uk.gov.justice.probation.courtcaseservice.security.AuthAwareAuthenticationToken;
-import uk.gov.justice.probation.courtcaseservice.service.AuthenticationHelper;
-import uk.gov.justice.probation.courtcaseservice.service.CaseCommentsService;
-import uk.gov.justice.probation.courtcaseservice.service.CaseProgressService;
-import uk.gov.justice.probation.courtcaseservice.service.CourtCaseService;
-import uk.gov.justice.probation.courtcaseservice.service.HearingNotesService;
-import uk.gov.justice.probation.courtcaseservice.service.OffenderMatchService;
-import uk.gov.justice.probation.courtcaseservice.service.OffenderUpdateService;
+import uk.gov.justice.probation.courtcaseservice.service.*;
 import uk.gov.justice.probation.courtcaseservice.service.model.CaseProgressHearing;
 import uk.gov.justice.probation.courtcaseservice.service.model.HearingSearchFilter;
 
@@ -85,6 +79,8 @@ class CourtCaseControllerTest {
     @Mock
     private HearingNotesService hearingNotesService;
     @Mock
+    private HearingEntityInitService hearingEntityInitService;
+    @InjectMocks
     private CourtCaseResponseMapper courtCaseResponseMapper;
 
     private CourtCaseController courtCaseController;

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/CourtCaseControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.kotlin.MockingKt;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.WebRequest;
 import reactor.core.publisher.Mono;
+import uk.gov.justice.probation.courtcaseservice.controller.mapper.CourtCaseResponseMapper;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CaseCommentRequest;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CaseCommentResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CaseListResponse;
@@ -83,6 +84,8 @@ class CourtCaseControllerTest {
     private CaseProgressService caseProgressService;
     @Mock
     private HearingNotesService hearingNotesService;
+    @Mock
+    private CourtCaseResponseMapper courtCaseResponseMapper;
 
     private CourtCaseController courtCaseController;
     private final HearingEntity hearingEntity = HearingEntity.builder()
@@ -110,7 +113,7 @@ class CourtCaseControllerTest {
     @BeforeEach
     public void setUp() {
         courtCaseController = new CourtCaseController(courtCaseService, offenderMatchService,
-            offenderUpdateService, caseCommentsService, authenticationHelper, caseProgressService, hearingNotesService, true);
+            offenderUpdateService, caseCommentsService, authenticationHelper, caseProgressService, hearingNotesService, courtCaseResponseMapper, true);
     }
 
     @Test
@@ -303,7 +306,7 @@ class CourtCaseControllerTest {
     @Test
     void givenCacheableCaseListDisabled_whenListIsNotModified_thenReturnFullList() {
         final var nonCachingController = new CourtCaseController(courtCaseService,
-            offenderMatchService, offenderUpdateService, caseCommentsService, authenticationHelper, caseProgressService, hearingNotesService, false);
+            offenderMatchService, offenderUpdateService, caseCommentsService, authenticationHelper, caseProgressService, hearingNotesService, courtCaseResponseMapper, false);
 
         final var courtCaseEntity = this.hearingEntity.withHearingDefendants(List.of(EntityHelper.aHearingDefendantEntity()))
                 .withHearingDays(Collections.singletonList(EntityHelper.aHearingDayEntity()

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/controller/mapper/CourtCaseResponseMapperTest.java
@@ -2,6 +2,10 @@ package uk.gov.justice.probation.courtcaseservice.controller.mapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.probation.courtcaseservice.controller.model.CourtCaseResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeResponse;
 import uk.gov.justice.probation.courtcaseservice.controller.model.OffenceResponse;
@@ -29,6 +33,7 @@ import uk.gov.justice.probation.courtcaseservice.jpa.entity.PleaEntity;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.Sex;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.SourceType;
 import uk.gov.justice.probation.courtcaseservice.jpa.entity.VerdictEntity;
+import uk.gov.justice.probation.courtcaseservice.service.HearingEntityInitService;
 import uk.gov.justice.probation.courtcaseservice.service.HearingOutcomeType;
 import uk.gov.justice.probation.courtcaseservice.service.model.CaseProgressHearing;
 
@@ -43,11 +48,12 @@ import java.util.UUID;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.DEFENDANT_ADDRESS;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.HEARING_ID;
 import static uk.gov.justice.probation.courtcaseservice.jpa.entity.EntityHelper.aDefendantOffence;
 
-
+@ExtendWith(MockitoExtension.class)
 class CourtCaseResponseMapperTest {
 
     private static final long ID = 1234L;
@@ -84,6 +90,13 @@ class CourtCaseResponseMapperTest {
     private static String DOCUMENT_ID = "document-id-one";
     private static String DOCUMENT_NAME = "document-name-one.pdf";
     private HearingEntity hearingEntity;
+
+    @Mock
+    private HearingEntityInitService hearingEntityInitService;
+
+    @InjectMocks
+    private CourtCaseResponseMapper courtCaseResponseMapper;
+
     private final AddressPropertiesEntity addressPropertiesEntity = AddressPropertiesEntity.builder()
             .line1("27")
             .line2("Elm Place")
@@ -104,7 +117,6 @@ class CourtCaseResponseMapperTest {
 
     @BeforeEach
     void setUp() {
-
         var hearings = Arrays.asList(
                 HearingDayEntity.builder()
                         .day(HEARING_DATE)
@@ -166,7 +178,7 @@ class CourtCaseResponseMapperTest {
                 .offences(singletonList(defendantOffence))
                 .build();
 
-        var courtCaseResponse = CourtCaseResponseMapper.mapFrom(hearingEntity, defendantEntity, 3, HEARING_DATE);
+        var courtCaseResponse = courtCaseResponseMapper.mapFrom(hearingEntity, defendantEntity, 3, HEARING_DATE);
 
         assertCaseFields(courtCaseResponse, null, SourceType.COMMON_PLATFORM);
         assertHearingFields(courtCaseResponse);
@@ -212,6 +224,7 @@ class CourtCaseResponseMapperTest {
 
     @Test
     void givenMultipleDefendants_whenMapByDefendantId_thenReturnCorrectDefendant() {
+        when(hearingEntityInitService.initializeCaseDocuments(hearingEntity)).thenReturn(hearingEntity);
 
         var newName = NamePropertiesEntity.builder().surname("PRESLEY").forename1("Elvis").build();
         var defendant1 = buildDefendant(newName, OffenderEntity.builder().crn("D99999").build());
@@ -219,8 +232,7 @@ class CourtCaseResponseMapperTest {
 
         var courtCase = hearingEntity.withHearingDefendants(List.of(defendant1, defendant2));
 
-
-        var response = CourtCaseResponseMapper.mapFrom(courtCase, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
+        var response = courtCaseResponseMapper.mapFrom(courtCase, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
 
         assertCaseFields(response);
         assertThat(response.getNumberOfPossibleMatches()).isEqualTo(5);
@@ -232,6 +244,7 @@ class CourtCaseResponseMapperTest {
 
     @Test
     void givenDefendantWithOffender_whenMapByDefendantId_thenReturnFieldsFromOffender() {
+        when(hearingEntityInitService.initializeCaseDocuments(hearingEntity)).thenReturn(hearingEntity);
 
         final var name = NamePropertiesEntity.builder().surname("TICKELL").forename1("Katherine").build();
         final OffenderEntity offender = OffenderEntity.builder().crn("W99999")
@@ -246,7 +259,7 @@ class CourtCaseResponseMapperTest {
 
         var courtCase = hearingEntity.withHearingDefendants(List.of(defendant));
 
-        var response = CourtCaseResponseMapper.mapFrom(courtCase, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
+        var response = courtCaseResponseMapper.mapFrom(courtCase, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
 
         assertThat(response.getProbationStatus()).isEqualTo("Previously known");
         assertThat(response.getCrn()).isEqualTo("W99999");
@@ -275,7 +288,7 @@ class CourtCaseResponseMapperTest {
 
         var hearingEntityUpdated = hearingEntity.withHearingDefendants(List.of(defendant));
 
-        var response = CourtCaseResponseMapper.mapFrom(hearingEntityUpdated, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
+        var response = courtCaseResponseMapper.mapFrom(hearingEntityUpdated, "bd1f71e5-939b-4580-8354-7d6061a58032", 5, caseProgressHearings);
 
         assertThat(response.getHearings().get(0).getHearingOutcome().getHearingOutcomeType()).isEqualTo(HearingOutcomeType.REPORT_REQUESTED);
     }
@@ -290,7 +303,7 @@ class CourtCaseResponseMapperTest {
 
         courtCase.getCaseDefendants().get(0).createDocument(DOCUMENT_ID, DOCUMENT_NAME);
 
-        var response = CourtCaseResponseMapper.mapFrom(hearing, EntityHelper.DEFENDANT_ID, 5, caseProgressHearings);
+        var response = courtCaseResponseMapper.mapFrom(hearing, EntityHelper.DEFENDANT_ID, 5, caseProgressHearings);
 
         var caseDocument = response.getFiles().get(0);
         assertThat(caseDocument.getId()).isEqualTo(DOCUMENT_ID);


### PR DESCRIPTION
Lazy load case documents

Turn courtCaseResponseMapper to a service class in order to use Transactional in order to use Hibernate.initialize.