### PR TITLE
BugFix pinger calls to external apis

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/application/healthchecks/NomisAuth.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/application/healthchecks/NomisAuth.java
@@ -18,7 +18,6 @@ public class NomisAuth implements ReactiveHealthIndicator {
 
     @Override
     public Mono<Health> health() {
-        pinger.setPath("/auth/health/ping");
         return pinger.ping(authWebClient);
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ community-api:
   base-url: https://community-api-secure.test.delius.probation.hmpps.dsd.io
 
 nomis-oauth:
-  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 offender-assessments-api:
   base-url: https://dev.devtest.assessment-api.hmpps.dsd.io
@@ -37,7 +37,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${nomis-oauth.base-url}/auth/.well-known/jwks.json
+          jwk-set-uri: ${nomis-oauth.base-url}/.well-known/jwks.json
 
 azure:
   application-insights:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -12,7 +12,7 @@ offender-assessments-api:
   client-secret: clientsecret
 
 nomis-oauth:
-  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 delius:
   base-url: https://ndelius.test.probation.service.justice.gov.uk

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ offender-assessments-api:
   client-secret: clientsecret
 
 nomis-oauth:
-  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 delius:
   base-url: https://ndelius.test.probation.service.justice.gov.uk
@@ -67,7 +67,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${nomis-oauth.base-url}/auth/.well-known/jwks.json
+          jwk-set-uri: ${nomis-oauth.base-url}/.well-known/jwks.json
   datasource:
     url: jdbc:postgresql://${database.endpoint:localhost:5432}/${database.name:postgres}?currentSchema=${database.schema.name:courtcaseservice}&user=${database.username:root}&password=${database.password:dev}&stringtype=unspecified
     hikari:

--- a/src/main/resources/application-wiremock.yml
+++ b/src/main/resources/application-wiremock.yml
@@ -12,7 +12,7 @@ offender-assessments-api:
   client-secret: clientsecret
 
 nomis-oauth:
-  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+  base-url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 delius:
   base-url: https://ndelius.test.probation.service.justice.gov.uk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,11 +81,11 @@ spring:
             provider: nomis-oauth-service
         provider:
           nomis-oauth-service:
-            token-uri: ${nomis-oauth.base-url}/auth/oauth/token
+            token-uri: ${nomis-oauth.base-url}/oauth/token
       resourceserver:
         jwt:
-          issuer-uri: ${nomis-oauth.issuer-base-url:${nomis-oauth.base-url}}/auth/issuer
-          jwk-set-uri: ${nomis-oauth.base-url}/auth/.well-known/jwks.json
+          issuer-uri: ${nomis-oauth.issuer-base-url:${nomis-oauth.base-url}}/issuer
+          jwk-set-uri: ${nomis-oauth.base-url}/.well-known/jwks.json
 
   datasource:
     url: jdbc:postgresql://${database.endpoint:localhost:5432}/${database.name:postgres}?currentSchema=${database.schema.name}&user=${database.username:root}&password=${database.password:dev}&stringtype=unspecified&sslmode=verify-full

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,7 +27,7 @@ prison-api:
   base-url: http://localhost:8090
 
 nomis-oauth:
-  base-url: http://localhost:8090
+  base-url: http://localhost:8090/auth
 
 manage-offences-api:
   base-url: http://localhost:8090
@@ -55,7 +55,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${nomis-oauth.base-url}/auth/.well-known/jwks.json
+          jwk-set-uri: ${nomis-oauth.base-url}/.well-known/jwks.json
 
   datasource:
     url: jdbc:postgresql://${database.endpoint:localhost:5432}/${database.name:postgres}?currentSchema=${database.schema.name}&user=${database.username:root}&password=${database.password:dev}&stringtype=unspecified


### PR DESCRIPTION
Remove (undo)  `pinger.setPath("/auth/health/ping")` of the [previous related PR](https://github.com/ministryofjustice/court-case-service/pull/1338) which affects all classes using `Pinger` causing all those other api health checks to end with `/auth/health/ping`

Set the base path of `nomis-auth` to have `/auth` appended to it

Undo `nomis-auth` ping path