### PR TITLE
Revert "Add uniq constraint on case_defendant table"

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2192__add_unique_constraint_to_case_defendant.sql
+++ b/src/main/resources/db/migration/courtcase/V2192__add_unique_constraint_to_case_defendant.sql
@@ -1,3 +1,0 @@
-BEGIN;
-    alter table if exists case_defendant ADD CONSTRAINT uniq_court_case_case_defendant UNIQUE (fk_court_case_id, fk_case_defendant_id);
-END;


### PR DESCRIPTION
Reverts ministryofjustice/court-case-service#1344

This is because the uniq index cannot be created when there are already duplicates in the table