### PR TITLE
PIC-4566: Try mapping 'No Record' explicitly instead

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantProbationStatus.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/DefendantProbationStatus.java
@@ -23,7 +23,11 @@ public enum DefendantProbationStatus {
     public static DefendantProbationStatus of(String status) {
         final var probationStatus = status == null ? DEFAULT.name() : status.trim().toUpperCase();
         try {
-            return DefendantProbationStatus.valueOf(probationStatus.replaceAll(" ", "_"));
+            String formattedString = probationStatus.replaceAll(" ", "_");
+            if(formattedString.equals("NO_RECORD")) {
+                return DefendantProbationStatus.UNCONFIRMED_NO_RECORD;
+            }
+            return DefendantProbationStatus.valueOf(formattedString);
         }
         catch (RuntimeException ex) {
             log.error("Unable to map {} to a known ProbationStatus enum value", status, ex);

--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/OffenderProbationStatus.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/OffenderProbationStatus.java
@@ -7,9 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 public enum OffenderProbationStatus {
     CURRENT(DefendantProbationStatus.CURRENT.name()),
     PREVIOUSLY_KNOWN(DefendantProbationStatus.PREVIOUSLY_KNOWN.name()),
-    NOT_SENTENCED(DefendantProbationStatus.NOT_SENTENCED.name()),
-    UNCONFIRMED_NO_RECORD(DefendantProbationStatus.UNCONFIRMED_NO_RECORD.name()),
-    CONFIRMED_NO_RECORD(DefendantProbationStatus.CONFIRMED_NO_RECORD.name());
+    NOT_SENTENCED(DefendantProbationStatus.NOT_SENTENCED.name());
 
     private final String name;
 
@@ -34,8 +32,6 @@ public enum OffenderProbationStatus {
             case CURRENT -> DefendantProbationStatus.CURRENT;
             case PREVIOUSLY_KNOWN -> DefendantProbationStatus.PREVIOUSLY_KNOWN;
             case NOT_SENTENCED -> DefendantProbationStatus.NOT_SENTENCED;
-            case UNCONFIRMED_NO_RECORD -> DefendantProbationStatus.UNCONFIRMED_NO_RECORD;
-            case CONFIRMED_NO_RECORD -> DefendantProbationStatus.CONFIRMED_NO_RECORD;
         };
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/OffenderProbationStatusTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcaseservice/jpa/entity/OffenderProbationStatusTest.java
@@ -12,8 +12,6 @@ class OffenderProbationStatusTest {
         assertThat(OffenderProbationStatus.of("CURRENT")).isSameAs(OffenderProbationStatus.CURRENT);
         assertThat(OffenderProbationStatus.of("NOT_SENTENCED")).isSameAs(OffenderProbationStatus.NOT_SENTENCED);
         assertThat(OffenderProbationStatus.of("PREVIOUSLY_KNOWN")).isSameAs(OffenderProbationStatus.PREVIOUSLY_KNOWN);
-        assertThat(OffenderProbationStatus.of("UNCONFIRMED_NO_RECORD")).isSameAs(OffenderProbationStatus.UNCONFIRMED_NO_RECORD);
-        assertThat(OffenderProbationStatus.of("CONFIRMED_NO_RECORD")).isSameAs(OffenderProbationStatus.CONFIRMED_NO_RECORD);
     }
 
     @Test
@@ -40,8 +38,6 @@ class OffenderProbationStatusTest {
         assertThat(OffenderProbationStatus.of("current")).isSameAs(OffenderProbationStatus.CURRENT);
         assertThat(OffenderProbationStatus.of("not sentenced")).isSameAs(OffenderProbationStatus.NOT_SENTENCED);
         assertThat(OffenderProbationStatus.of("previously known")).isSameAs(OffenderProbationStatus.PREVIOUSLY_KNOWN);
-        assertThat(OffenderProbationStatus.of("unconfirmed no record")).isSameAs(OffenderProbationStatus.UNCONFIRMED_NO_RECORD);
-        assertThat(OffenderProbationStatus.of("confirmed no record")).isSameAs(OffenderProbationStatus.CONFIRMED_NO_RECORD);
     }
 
     @Test
@@ -49,8 +45,6 @@ class OffenderProbationStatusTest {
         assertThat(OffenderProbationStatus.CURRENT.asDefendantProbationStatus()).isEqualTo(DefendantProbationStatus.CURRENT);
         assertThat(OffenderProbationStatus.PREVIOUSLY_KNOWN.asDefendantProbationStatus()).isEqualTo(DefendantProbationStatus.PREVIOUSLY_KNOWN);
         assertThat(OffenderProbationStatus.NOT_SENTENCED.asDefendantProbationStatus()).isEqualTo(DefendantProbationStatus.NOT_SENTENCED);
-        assertThat(OffenderProbationStatus.UNCONFIRMED_NO_RECORD.asDefendantProbationStatus()).isEqualTo(DefendantProbationStatus.UNCONFIRMED_NO_RECORD);
-        assertThat(OffenderProbationStatus.CONFIRMED_NO_RECORD.asDefendantProbationStatus()).isEqualTo(DefendantProbationStatus.CONFIRMED_NO_RECORD);
     }
 }
 


### PR DESCRIPTION
Try mapping 'No Record' explicitly instead of in the exception, revert OffenderProbation changes