### PR TITLE
PIC-4640 allow downloading 50mb file max

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcaseservice/application/WebClientConfig.java
+++ b/src/main/java/uk/gov/justice/probation/courtcaseservice/application/WebClientConfig.java
@@ -131,7 +131,7 @@ public class WebClientConfig {
 
     @Bean
     public WebClient hmppsDocumentManagementApiWebClient(WebClientFactory webClientFactory) {
-        return webClientFactory.buildWebClient(hmppsDocumentManagementApiUrl, 17 * DEFAULT_BYTE_BUFFER_SIZE);
+        return webClientFactory.buildWebClient(hmppsDocumentManagementApiUrl, 190 * DEFAULT_BYTE_BUFFER_SIZE);
     }
 
 }


### PR DESCRIPTION
Increase to 50MB because our service allows for 50mb files to be uploaded to HMPPS Document API Service.