### PR TITLE
PIC-4650 Use eclipse java image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim-buster
+FROM eclipse-temurin:21-jre-jammy
 MAINTAINER HMPPS Digital Studio <info@digital.justice.gov.uk>
 
 ENV TZ=Europe/London


### PR DESCRIPTION
This contains less cve security vulnerabilities. (tested locally successfully)