### PR TITLE
Add index to case_marker table

### DIFF
--- a/src/main/resources/db/migration/courtcase/V2196__add_index_case_marker.sql
+++ b/src/main/resources/db/migration/courtcase/V2196__add_index_case_marker.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS case_marker_fk_court_case_id_idx ON case_marker (fk_court_case_id);
+
+COMMIT;


### PR DESCRIPTION
This should help speed up requests to the table on fk_court_case_id

Thus improving the overall performance of getting "court cases" as a whole as it has an association to it.

It's a Hibernate made query that in one request could accumulate to 100 milliseconds or so.

> SELECT case_marker

[example of logs in Azure](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%22484e0864-408c-11f0-be51-002248c5d09f%22,%22timestamp%22:%222025-06-03T15:06:01.889Z%22%7D/ComponentId/%7B%22Name%22:%22nomisapi-prod%22,%22ResourceGroup%22:%22nomisapi-prod-rg%22,%22SubscriptionId%22:%22a5ddf257-3b21-4ba9-a28c-ab30f751b383%22%7D)

[example 2](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz3LMQ6AIBAF0d5TEHo8ioUXIJvlJxBhMQto4%252BHFxnKSNwEnJEA4oS2PuSMUhnMdwe81Y6Mys0qnJM1YrkO7Y2pwDXolhv0n%252BWikqdYP%252BEJ6QO0L%252FD6HPGEAAAA%253D/timespan/P1D/limit/1000)