### PR TITLE
Update data extractor to latest

### DIFF
--- a/helm_deploy/court-case-service/templates/analytics-data-extractor-cronjob.yaml
+++ b/helm_deploy/court-case-service/templates/analytics-data-extractor-cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: "Never"
           containers:
             - name: data-extractor-analytics
-              image: ministryofjustice/data-engineering-data-extractor:v1
+              image: ministryofjustice/data-engineering-data-extractor:sha-b84888b
               imagePullPolicy: Always
               args: ["extract_table_names.py &&
                     extract_pg_jsonl_snapshot.py &&


### PR DESCRIPTION
We had a critical alert from dependabot in the data extractor repository which required us to bump a few dependencies and create a new release. This PR bumps the data extractor to the latest release. We've tested this with the calculate-release-dates service and it worked without issue. Hope this is ok - happy to discuss. Thanks!