### PR TITLE
ensure consistent ordering in paginated outcomes list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustom.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeItemState
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSearchRequest
 import uk.gov.justice.probation.courtcaseservice.controller.model.HearingOutcomeSortFields.HEARING_DATE
+import uk.gov.justice.probation.courtcaseservice.controller.model.SortOrder
 import uk.gov.justice.probation.courtcaseservice.jpa.dto.HearingDefendantDTO
 import java.time.LocalDate
 
@@ -55,16 +56,17 @@ class HearingOutcomeRepositoryCustom(
       }
     }
 
+    // include sort by id to ensure consistency throughout pagination
     val orderByBuilder = StringBuilder(" order by ")
     if (hearingOutcomeSearchRequest.sortBy == null) {
-      orderByBuilder.append("hday2.hearing_day")
+      orderByBuilder.append("hday2.hearing_day, hd.id")
     } else {
       // only sort by hearing date supported at the moment
       if (hearingOutcomeSearchRequest.sortBy == HEARING_DATE) {
-        orderByBuilder.append("hday2.hearing_day ")
-        hearingOutcomeSearchRequest.order?.let { orderByBuilder.append(it.name) }
+        val direction = hearingOutcomeSearchRequest.order?.name ?: SortOrder.ASC.name
+        orderByBuilder.append("hday2.hearing_day $direction, hd.id $direction")
       } else {
-        orderByBuilder.append("hday2.hearing_day")
+        orderByBuilder.append("hday2.hearing_day, hd.id")
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomPaginationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/probation/courtcaseservice/jpa/repository/HearingOutcomeRepositoryCustomPaginationIntTest.kt
@@ -33,6 +33,7 @@ internal class HearingOutcomeRepositoryCustomPaginationIntTest {
     assertThat(result.content.size).isEqualTo(2)
     assertThat(result.content[0].first.hearing.hearingId).isEqualTo("2aa6f5e0-f842-4939-bc6a-01346abc09e7")
     assertThat(result.content[1].first.hearing.hearingId).isEqualTo("1f93aa0a-7e46-4885-a1cb-f25a4be33a00")
+    assertThat(result.content[0].first.id).isLessThan(result.content[1].first.id)
     assertThat(result.size).isEqualTo(2)
     assertThat(result.totalPages).isEqualTo(2)
     assertThat(result.totalElements).isEqualTo(3)


### PR DESCRIPTION
When retrieving outcomes on PACFS, results are sorted by hearing day. Because there can be multiple hearings with the same hearing day, the order in which they are returned is indeterminate. Combined with results being paginated, this can lead to duplicate hearings being displayed across different pages as well as missing hearings.

This PR attempts to fix this issue by sorting on hearing defendant ID as well, ensuring consistent results.